### PR TITLE
fix: lower CPU limit to 1.0 for single-CPU VPS

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.0"
+          cpus: "1.0"
           memory: 1G
         reservations:
           cpus: "0.25"


### PR DESCRIPTION
docker-compose.prod.yml had cpus: 2.0 which fails on a single-CPU host.