### PR TITLE
fix: change app port to 8989

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM node:20-bookworm-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV PORT=3000
+ENV PORT=8989
 ENV HOSTNAME=0.0.0.0
 RUN addgroup --system --gid 1001 nodejs \
   && adduser --system --uid 1001 --ingroup nodejs nextjs
@@ -26,7 +26,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 RUN mkdir -p /app/public
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data /app/public
 USER nextjs
-EXPOSE 3000
+EXPOSE 8989
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get({path:'/api/health',port:3000,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+  CMD node -e "require('http').get({path:'/api/health',port:8989,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 CMD ["node", "server.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,7 @@ services:
       - traefik-public
     environment:
       NODE_ENV: production
-      PORT: 3000
+      PORT: 8989
       HOSTNAME: "0.0.0.0"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
@@ -37,7 +37,7 @@ services:
     volumes:
       - techscribe-data:/app/data
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get({path:'/api/health',port:3000,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "require('http').get({path:'/api/health',port:8989,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -64,7 +64,7 @@ services:
       - "traefik.http.routers.techscribe.tls=true"
       - "traefik.http.routers.techscribe.tls.certresolver=letsencrypt"
       # ── Service ────────────────────────────────────────────────────────────
-      - "traefik.http.services.techscribe.loadbalancer.server.port=3000"
+      - "traefik.http.services.techscribe.loadbalancer.server.port=8989"
       # Disable Traefik response buffering so streaming generation works
       - "traefik.http.middlewares.techscribe-buffering.buffering.maxResponseBodyBytes=0"
       - "traefik.http.routers.techscribe.middlewares=techscribe-buffering"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
     build: .
     image: techscribe-studio:local
     ports:
-      - "3000:3000"
+      - "8989:8989"
     environment:
       NODE_ENV: production
-      PORT: 3000
+      PORT: 8989
       HOSTNAME: "0.0.0.0"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
-      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:8989}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       WORDPRESS_SITE_URL: ${WORDPRESS_SITE_URL}
@@ -27,7 +27,7 @@ services:
       - techscribe-data:/app/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get({path:'/api/health',port:3000,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "require('http').get({path:'/api/health',port:8989,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Change app listening port from 3000 to 8989 across Dockerfile, docker-compose.yml, and docker-compose.prod.yml (PORT env var, EXPOSE, health checks, Traefik loadbalancer port).