### PR TITLE
fix: correct standalone Docker setup and add /api/healthz route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@
 FROM node:20-bookworm-slim AS deps
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
+# Build tools required for native modules (e.g. better-sqlite3)
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
 RUN npm ci --legacy-peer-deps
 
 FROM deps AS builder
+ENV NEXT_TELEMETRY_DISABLED=1
 COPY . .
 RUN npm run build
 
@@ -17,16 +19,25 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=8989
 ENV HOSTNAME=0.0.0.0
+
 RUN addgroup --system --gid 1001 nodejs \
   && adduser --system --uid 1001 --ingroup nodejs nextjs
-# Copy standalone Next.js output (includes only necessary node_modules)
+
+# Standalone output: server.js + minimal node_modules + .next/server
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+# Static assets (_next/static) must be served separately from standalone
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-# public/ is optional — only copy if it exists
-RUN mkdir -p /app/public
-RUN mkdir -p /app/data && chown nextjs:nodejs /app/data /app/public
+# Public assets (favicons, robots.txt, etc.)
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# Persistent data directory for SQLite (mounted as a volume in production)
+RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
+
 USER nextjs
 EXPOSE 8989
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get({path:'/api/health',port:8989,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD node -e "\
+    const req = require('http').get({path:'/api/health',port:8989,timeout:8000},(r)=>process.exit(r.statusCode===200?0:1));\
+    req.on('timeout',()=>{req.destroy();process.exit(1)});\
+    req.on('error',()=>process.exit(1));"
 CMD ["node", "server.js"]

--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,0 +1,2 @@
+// Alias for /api/health — used by infrastructure probes (Traefik, k8s, etc.)
+export { GET, dynamic } from "@/app/api/health/route";


### PR DESCRIPTION
- Add missing COPY public in runner stage (was only mkdir'd, not populated)
- Add ENV NEXT_TELEMETRY_DISABLED=1 to builder stage so it applies during build
- Fix HEALTHCHECK to properly handle socket timeout (req.on('timeout') + req.destroy()) so slow starts don't hang until Docker's outer timeout
- Increase start_period from 40s to 60s to give Next.js more warm-up time
- Add /api/healthz route as an alias for /api/health for infrastructure probes (Traefik, k8s, etc.) that expect the conventional /healthz path