### PR TITLE
fix: production Docker fixes, auth guards, and /api/healthz route

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -35,7 +35,9 @@ export async function PATCH(req: Request) {
     const userBefore = listUsers().find((u) => u.id === body.id);
     updateUserStatus(body.id, body.status, adminEmail);
     if (body.status === "approved" && userBefore?.status !== "approved") {
-      sendApprovalNotification({ name: userBefore?.name ?? null, email: userBefore?.email ?? "" }).catch(() => {});
+      sendApprovalNotification({ name: userBefore?.name ?? null, email: userBefore?.email ?? "" }).catch((err) => {
+        console.error("Approval notification email failed:", err);
+      });
     }
   }
 

--- a/app/api/automation/runs/route.ts
+++ b/app/api/automation/runs/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
 import { listAutomationRuns } from "@/lib/db";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
 export async function GET() {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     return NextResponse.json({ runs: listAutomationRuns() });
   } catch (error) {

--- a/app/api/automation/templates/route.ts
+++ b/app/api/automation/templates/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAutomationTemplate, listAutomationTemplates } from "@/lib/db";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
 export async function GET() {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     return NextResponse.json({ templates: listAutomationTemplates() });
   } catch (error) {
@@ -13,6 +17,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json() as Record<string, unknown>;
     const name = String(body.name ?? "").trim();

--- a/app/api/calendar/[id]/route.ts
+++ b/app/api/calendar/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db";
 import { type CalendarChecklistItem, isCalendarApprovalStatus, isCalendarPublishIntent, isCalendarStatus } from "@/lib/calendar";
 import { getToolBySlug } from "@/lib/tools";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -52,6 +53,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const { id: rawId } = await params;
     const id = parseId(rawId);
@@ -124,6 +128,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const { id: rawId } = await params;
     const id = parseId(rawId);

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db";
 import { type CalendarChecklistItem, isCalendarApprovalStatus, isCalendarPublishIntent, isCalendarStatus } from "@/lib/calendar";
 import { getToolBySlug } from "@/lib/tools";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -44,6 +45,9 @@ function normalizeChecklistItems(value: unknown) {
 }
 
 export async function GET(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const { searchParams } = new URL(req.url);
     const statusParam = searchParams.get("status")?.trim() ?? "";
@@ -73,6 +77,9 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json() as Record<string, unknown>;
     const title = String(body.title ?? "").trim();

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { NextRequest } from "next/server";
 import { getToolBySlug } from "@/lib/tools";
 import { rateLimit, getRequestIp } from "@/lib/rate-limit";
+import { requireApprovedSession } from "@/lib/auth";
 
 const client = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -26,6 +27,9 @@ function buildResearchSection(research: ResearchItem[]): string {
 }
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   const ip = getRequestIp(req.headers);
   if (!rateLimit(`generate:${ip}`, 60, 60_000)) {
     return new Response(JSON.stringify({ error: "Too many requests. Please wait a moment and try again." }), {

--- a/app/api/history/[id]/route.ts
+++ b/app/api/history/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { deleteHistory, getHistoryById, updateHistoryMetadata, updateHistoryOutput } from "@/lib/db";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -8,6 +9,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   const { id: rawId } = await params;
   const id = parseInt(rawId, 10);
   if (isNaN(id)) {
@@ -25,6 +29,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   const { id: rawId } = await params;
   const id = parseInt(rawId, 10);
   if (isNaN(id)) {
@@ -41,6 +48,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   const { id: rawId } = await params;
   const id = parseInt(rawId, 10);
 

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { countHistory, getCalendarEntryById, linkCalendarEntryToHistory, saveHistory, listHistory } from "@/lib/db";
 import { getToolBySlug } from "@/lib/tools";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -18,6 +19,9 @@ function toIsoExclusiveEnd(date: string | null) {
 
 // GET /api/history — list saved generations
 export async function GET(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   const { searchParams } = new URL(req.url);
   const toolSlug = searchParams.get("tool") ?? undefined;
   const folder = searchParams.get("folder")?.trim() || undefined;
@@ -63,6 +67,9 @@ export async function GET(req: NextRequest) {
 
 // POST /api/history — save a generation
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json();
     const { slug, fields, output, calendarId } = body;

--- a/app/api/seo/analyze/route.ts
+++ b/app/api/seo/analyze/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -112,6 +113,9 @@ function buildChecks(title: string, output: string, focusKeyword: string): SeoCh
 }
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json() as {
       title?: string;

--- a/app/api/settings/wordpress/route.ts
+++ b/app/api/settings/wordpress/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getWordPressSettings, saveWordPressSettings } from "@/lib/db";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
@@ -20,6 +21,9 @@ function getEnvFallback() {
 }
 
 export async function GET() {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const saved = getWordPressSettings();
 
@@ -43,6 +47,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json();
     const siteUrl = String(body.site_url ?? "").trim().replace(/\/$/, "");

--- a/app/api/settings/wordpress/test/route.ts
+++ b/app/api/settings/wordpress/test/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveWordPressConfig, testWordPressConnection } from "@/lib/wordpress";
+import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
+  const auth = await requireApprovedSession();
+  if ("error" in auth) return auth.error;
+
   try {
     const body = await req.json();
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,6 @@
 import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
 import GoogleProvider from "next-auth/providers/google";
 import { upsertUser, getUserByGoogleId } from "@/lib/db";
 import { sendNewUserNotification } from "@/lib/email";
@@ -24,7 +26,9 @@ export const authOptions: NextAuthOptions = {
       });
       if (isNew) {
         // Fire-and-forget — don't block sign-in if email fails
-        sendNewUserNotification({ name: user.name ?? null, email: user.email! }).catch(() => {});
+        sendNewUserNotification({ name: user.name ?? null, email: user.email! }).catch((err) => {
+          console.error("New user notification email failed:", err);
+        });
       }
       return true;
     },
@@ -56,3 +60,23 @@ export const authOptions: NextAuthOptions = {
     },
   },
 };
+
+/**
+ * Call at the top of any API route handler that requires an approved user.
+ * Returns { error: NextResponse } if the request should be rejected,
+ * or { session } if the user is authenticated and approved.
+ */
+export async function requireApprovedSession(): Promise<
+  | { error: NextResponse }
+  | { session: NonNullable<Awaited<ReturnType<typeof getServerSession>>> }
+> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+  const status = (session.user as Record<string, unknown>).status;
+  if (status !== "approved") {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+  return { session: session as NonNullable<typeof session> };
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -5,6 +5,15 @@ interface RateLimitEntry {
 
 const store = new Map<string, RateLimitEntry>();
 
+// Periodically purge expired entries to prevent unbounded memory growth.
+// Runs every 5 minutes; safe to call on a module-level interval.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (now > entry.resetAt) store.delete(key);
+  }
+}, 5 * 60 * 1000);
+
 /**
  * Simple in-memory rate limiter. Appropriate for single-instance deployments.
  * Returns true if the request is allowed, false if the limit has been exceeded.
@@ -25,7 +34,6 @@ export function rateLimit(key: string, limit: number, windowMs: number): boolean
   entry.count++;
   return true;
 }
-
 /** Extract a best-effort IP key from a Next.js request for rate limiting. */
 export function getRequestIp(headers: Headers): string {
   const forwarded = headers.get("x-forwarded-for");


### PR DESCRIPTION
## Summary

Fixes all production blockers identified in audit:

### Docker
- **Fix standalone COPY** — add missing `COPY public`, fix healthcheck timeout handling, increase `start_period` to 60s
- **Add `/api/healthz`** — alias for `/api/health` for infra probes
- **Create `public/.gitkeep`** — prevents Docker build failure on empty `public/` dir

### Security — API auth guards
All API routes were completely unprotected. Added `requireApprovedSession()` helper to `lib/auth.ts` and applied it to:
- `/api/generate` — Claude API was open to anyone
- `/api/history` and `/api/history/[id]`
- `/api/calendar` and `/api/calendar/[id]`
- `/api/settings/wordpress` and `/api/settings/wordpress/test` (WordPress credentials were leaking)
- `/api/automation/templates` and `/api/automation/runs`
- `/api/seo/analyze`

### Bug fixes
- **Rate-limiter memory leak** — add 5-min `setInterval` to purge expired entries
- **Silent email failures** — log errors instead of swallowing them