### PR TITLE
fix: inline dynamic export in healthz route

### DIFF
--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,2 +1,3 @@
 // Alias for /api/health — used by infrastructure probes (Traefik, k8s, etc.)
-export { GET, dynamic } from "@/app/api/health/route";
+export { GET } from "@/app/api/health/route";
+export const dynamic = "force-dynamic";


### PR DESCRIPTION
Next.js route segment config (like `dynamic`) cannot be re-exported from another module — it must be declared inline. Fixes CI build error.