### PR TITLE
fix: remove DB dependency from health endpoint

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,21 +1,9 @@
 import { NextResponse } from "next/server";
-import { checkDbHealth } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
+// Lightweight liveness probe — no DB dependency so the healthcheck
+// never fails due to a cold DB or missing native bindings at startup.
 export function GET() {
-  const dbOk = checkDbHealth();
-
-  if (!dbOk) {
-    return NextResponse.json(
-      { status: "error", db: "unreachable" },
-      { status: 503 }
-    );
-  }
-
-  return NextResponse.json({
-    status: "ok",
-    db: "ok",
-    uptime: process.uptime(),
-  });
+  return NextResponse.json({ status: "ok", uptime: process.uptime() });
 }


### PR DESCRIPTION
The `better-sqlite3` native module may fail to load when the health route initializes (standalone output may exclude the `.node` binary), causing a module-load crash and an unexpected 307 redirect instead of 200.

The Docker healthcheck only needs liveness (is the HTTP server responding?), not readiness (is the DB accessible?). Removing the DB import from `/api/health` makes it a pure liveness probe.