### PR TITLE
fix: restore middleware.ts with health endpoints as public paths

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { getToken } from "next-auth/jwt";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_PATHS = [
+  "/login",
+  "/pending",
+  "/api/auth",
+  "/api/health",
+  "/api/healthz",
+];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+    return NextResponse.next();
+  }
+
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
+  if (!token) {
+    // API routes get a 401 JSON response; pages get redirected to login
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const loginUrl = new URL("/login", req.url);
+    loginUrl.searchParams.set("callbackUrl", req.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (token.status !== "approved") {
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return NextResponse.redirect(new URL("/pending", req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
**Root cause of 307 on /api/health:**

`middleware.ts` was renamed to `proxy.ts` in a previous commit — but Next.js only recognizes the file if it's named `middleware.ts`. So no middleware was running in the new image at all.

The GHCR image was still built from an older state where `middleware.ts` existed and redirected ALL routes (including `/api/health`) to `/login` when unauthenticated — even though the health endpoint needs no auth.

**Fix:**
- Restore `middleware.ts` so Next.js actually runs it
- Add `/api/health` and `/api/healthz` to `PUBLIC_PATHS` so Docker healthchecks always return 200
- Return 401 JSON for unauthenticated API calls (instead of 307 redirect)