### PR TITLE
feat: UI redesign phases 1-6 + competitive feature expansion

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -39,13 +39,15 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { slug, fields, mode, outline, research, includePhotos } = await req.json() as {
+    const { slug, fields, mode, outline, research, includePhotos, toneInstruction, model } = await req.json() as {
       slug: string;
       fields: Record<string, string>;
       mode?: string;
       outline?: string;
       research?: ResearchItem[];
       includePhotos?: boolean;
+      toneInstruction?: string;
+      model?: string;
     };
 
     if (!slug || !fields) {
@@ -97,6 +99,11 @@ export async function POST(req: NextRequest) {
       userPrompt = userPrompt.replaceAll("{contextSection}", contextSection);
     }
 
+    // Append MyTone instructions to the system prompt when provided
+    if (toneInstruction?.trim()) {
+      systemPrompt += toneInstruction;
+    }
+
     // Append any research sources to the prompt
     if (research && research.length > 0) {
       userPrompt += buildResearchSection(research);
@@ -117,9 +124,12 @@ export async function POST(req: NextRequest) {
         "Do not cluster photos together; spread them evenly across the article.";
     }
 
+    const ALLOWED_MODELS = new Set(["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-7"]);
+    const resolvedModel = (model && ALLOWED_MODELS.has(model)) ? model : "claude-sonnet-4-6";
+
     // Stream the response
     const stream = await client.messages.stream({
-      model: "claude-opus-4-5",
+      model: resolvedModel,
       max_tokens: 4096,
       system: systemPrompt,
       messages: [{ role: "user", content: userPrompt }],

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,9 +1,50 @@
 import { NextRequest, NextResponse } from "next/server";
-import { countHistory, getCalendarEntryById, linkCalendarEntryToHistory, saveHistory, listHistory } from "@/lib/db";
+import { countHistory, getCalendarEntryById, linkCalendarEntryToHistory, saveHistory, listHistory, type HistoryRow } from "@/lib/db";
 import { getToolBySlug } from "@/lib/tools";
 import { requireApprovedSession } from "@/lib/auth";
 
 export const runtime = "nodejs";
+
+const STOP_WORDS = new Set(["a","an","the","and","or","but","in","on","at","to","for","of","with","by","from","is","are","was","were","be","been","has","have","had","do","does","did","will","would","could","should","may","might","i","you","he","she","it","we","they","this","that","these","those","how","what","when","where","why","which","who","about","like","just","not","can","get","use","make","into"]);
+
+function extractKeywords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s,;|/\\+\-–—]+/)
+    .map((w) => w.replace(/[^a-z0-9]/g, ""))
+    .filter((w) => w.length > 3 && !STOP_WORDS.has(w));
+}
+
+function checkCannibalization(
+  title: string,
+  keywords: string,
+  excludeId: number
+): Array<{ id: number; title: string }> | null {
+  try {
+    const newKeywords = new Set([...extractKeywords(title), ...extractKeywords(keywords)]);
+    if (newKeywords.size === 0) return null;
+
+    // Search recent history for any entry whose title shares 2+ significant keywords
+    const recent = listHistory(200, {}, 0) as HistoryRow[];
+    const matches: Array<{ id: number; title: string }> = [];
+
+    for (const row of recent) {
+      if (row.id === excludeId) continue;
+      const rowKeywords = new Set([
+        ...extractKeywords(row.title),
+        ...extractKeywords(JSON.parse(row.fields as string)?.keywords ?? ""),
+      ]);
+      const overlap = [...newKeywords].filter((kw) => rowKeywords.has(kw));
+      if (overlap.length >= 2) {
+        matches.push({ id: row.id, title: row.title });
+      }
+    }
+
+    return matches.length > 0 ? matches.slice(0, 3) : null;
+  } catch {
+    return null;
+  }
+}
 
 function toIsoStart(date: string | null) {
   if (!date) return undefined;
@@ -125,7 +166,14 @@ export async function POST(req: NextRequest) {
       linkCalendarEntryToHistory(calendarId, entry.id);
     }
 
-    return NextResponse.json(entry, { status: 201 });
+    // Cannibalization check: find existing history entries that share keywords/topic
+    const cannibalizationWarning = checkCannibalization(
+      String(title),
+      String(fields.keywords ?? fields.keyword ?? fields.seedKeyword ?? ""),
+      entry.id
+    );
+
+    return NextResponse.json({ ...entry, cannibalizationWarning }, { status: 201 });
   } catch (err) {
     console.error("History POST error:", err);
     return NextResponse.json({ error: "Failed to save history" }, { status: 500 });

--- a/app/blueprint/page.tsx
+++ b/app/blueprint/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowRight,
+  FileText,
+  Layers,
+  Megaphone,
+  Share2,
+  Video,
+  Zap,
+} from "lucide-react";
+
+interface BlueprintStep {
+  toolSlug: string;
+  label: string;
+  description: string;
+}
+
+interface Blueprint {
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  color: string;
+  accent: string;
+  time: string;
+  steps: BlueprintStep[];
+}
+
+const BLUEPRINTS: Blueprint[] = [
+  {
+    id: "blog-from-keyword",
+    title: "Blog Post from Keyword",
+    description: "Start with raw keyword research and produce a fully-optimised article, meta tags, and social posts — all in sequence.",
+    icon: <FileText className="w-5 h-5" />,
+    color: "from-teal-500/10 to-sky-500/10 border-teal-500/20",
+    accent: "text-teal-600",
+    time: "~25 min",
+    steps: [
+      { toolSlug: "keyword-research-brief", label: "Keyword Research Brief", description: "Turn raw keyword data into an actionable content brief." },
+      { toolSlug: "keyword-cluster", label: "Keyword Cluster", description: "Group related keywords by intent." },
+      { toolSlug: "headline-generator", label: "Headline Generator", description: "Write 10 title options and pick the best." },
+      { toolSlug: "outline-generator", label: "Outline Generator", description: "Build the H2/H3 structure." },
+      { toolSlug: "article-writer", label: "Article Writer", description: "Generate the full SEO-optimised post." },
+      { toolSlug: "faq-writer", label: "FAQ Writer", description: "Add an FAQ section for featured snippets." },
+      { toolSlug: "meta-title", label: "Meta Title", description: "Write a click-worthy title under 60 chars." },
+      { toolSlug: "meta-description", label: "Meta Description", description: "Write the 150-char search snippet." },
+    ],
+  },
+  {
+    id: "video-repurpose",
+    title: "Video → Full Content Pack",
+    description: "Take a YouTube video or podcast transcript and repurpose it into a blog post, social captions, and an email newsletter.",
+    icon: <Video className="w-5 h-5" />,
+    color: "from-purple-500/10 to-pink-500/10 border-purple-500/20",
+    accent: "text-purple-600",
+    time: "~15 min",
+    steps: [
+      { toolSlug: "youtube-to-blog", label: "YouTube → Blog Post", description: "Convert the transcript into a full article." },
+      { toolSlug: "key-takeaways", label: "Key Takeaways", description: "Extract the 5 most shareable insights." },
+      { toolSlug: "tweet-ideas", label: "Tweet / X Thread", description: "Turn the post into a tweet thread." },
+      { toolSlug: "linkedin-post", label: "LinkedIn Post", description: "Write a professional post for LinkedIn." },
+      { toolSlug: "instagram-caption", label: "Instagram Caption", description: "Short caption + hashtag pack." },
+      { toolSlug: "newsletter-writer", label: "Newsletter Issue", description: "Package the content as an email newsletter." },
+    ],
+  },
+  {
+    id: "seo-full-stack",
+    title: "SEO Content Sprint",
+    description: "Close content gaps, build keyword clusters, write the article, and generate all the technical SEO metadata in one go.",
+    icon: <Layers className="w-5 h-5" />,
+    color: "from-amber-500/10 to-orange-500/10 border-amber-500/20",
+    accent: "text-amber-600",
+    time: "~30 min",
+    steps: [
+      { toolSlug: "content-gap", label: "Content Gap Analyzer", description: "Find the topics competitors cover that you don't." },
+      { toolSlug: "keyword-cluster", label: "Keyword Cluster", description: "Group target keywords by search intent." },
+      { toolSlug: "outline-generator", label: "Outline Generator", description: "Structure the article to cover every angle." },
+      { toolSlug: "article-writer", label: "Article Writer", description: "Generate the full long-form post." },
+      { toolSlug: "schema-markup", label: "Schema Markup", description: "Add JSON-LD for rich results." },
+      { toolSlug: "og-meta-tags", label: "OG & Twitter Tags", description: "Control how the post looks on social." },
+      { toolSlug: "permalink-generator", label: "URL / Permalink", description: "Generate a clean, keyword-rich slug." },
+    ],
+  },
+  {
+    id: "social-campaign",
+    title: "Social Media Campaign",
+    description: "Write an article then fan it out across every social channel — Twitter, LinkedIn, Instagram, TikTok — plus an email blast.",
+    icon: <Share2 className="w-5 h-5" />,
+    color: "from-sky-500/10 to-indigo-500/10 border-sky-500/20",
+    accent: "text-sky-600",
+    time: "~20 min",
+    steps: [
+      { toolSlug: "article-writer", label: "Article Writer", description: "Create the source article to repurpose." },
+      { toolSlug: "key-takeaways", label: "Key Takeaways", description: "Distil the core insights." },
+      { toolSlug: "tweet-ideas", label: "Tweet / X Thread", description: "High-engagement thread or standalone posts." },
+      { toolSlug: "linkedin-post", label: "LinkedIn Post", description: "Professional long-form post." },
+      { toolSlug: "instagram-caption", label: "Instagram Caption", description: "Visual-first caption + hashtags." },
+      { toolSlug: "tiktok-caption", label: "TikTok Ideas & Caption", description: "Short-form video concepts from the post." },
+      { toolSlug: "email-subject-line", label: "Email Subject Line", description: "High-open-rate subject line options." },
+      { toolSlug: "newsletter-writer", label: "Newsletter Issue", description: "Full email newsletter body." },
+    ],
+  },
+  {
+    id: "launch-campaign",
+    title: "Product / Content Launch",
+    description: "Announce something new with a press release, email campaign, and a full social push — all co-ordinated in one workflow.",
+    icon: <Megaphone className="w-5 h-5" />,
+    color: "from-rose-500/10 to-red-500/10 border-rose-500/20",
+    accent: "text-rose-600",
+    time: "~20 min",
+    steps: [
+      { toolSlug: "press-release", label: "Press Release", description: "Write a newswire-ready announcement." },
+      { toolSlug: "aida-copy", label: "AIDA Copy", description: "Persuasive copy for the landing page or email." },
+      { toolSlug: "email-subject-line", label: "Email Subject Lines", description: "10 options to A/B test the launch email." },
+      { toolSlug: "cta-writer", label: "CTA Writer", description: "Write the button text and surrounding copy." },
+      { toolSlug: "tweet-ideas", label: "Launch Tweets", description: "Thread to announce on X / Twitter." },
+      { toolSlug: "linkedin-post", label: "LinkedIn Announcement", description: "Professional launch post." },
+    ],
+  },
+  {
+    id: "quick-wins",
+    title: "Quick Wins Sprint",
+    description: "Three fast standalone tasks: fix a draft, generate social captions, and optimise meta tags. Each takes under 2 minutes.",
+    icon: <Zap className="w-5 h-5" />,
+    color: "from-green-500/10 to-emerald-500/10 border-green-500/20",
+    accent: "text-green-600",
+    time: "~5 min",
+    steps: [
+      { toolSlug: "grammar-fixer", label: "Grammar & Style Fixer", description: "Proofread a draft before publishing." },
+      { toolSlug: "content-shortener", label: "Content Shortener", description: "Tighten a section that's running long." },
+      { toolSlug: "paraphrase", label: "Paraphrase Tool", description: "Reword a section that feels repetitive." },
+      { toolSlug: "meta-title", label: "Meta Title", description: "Quick SEO title refresh." },
+      { toolSlug: "meta-description", label: "Meta Description", description: "Write or update the search snippet." },
+    ],
+  },
+];
+
+export default function BlueprintPage() {
+  return (
+    <div className="min-h-screen">
+      <div className="p-5 md:p-8 max-w-6xl w-full mx-auto space-y-8">
+
+        {/* Hero */}
+        <div className="shell-panel rounded-[2rem] p-8 relative overflow-hidden">
+          <div className="absolute right-0 top-0 h-40 w-40 rounded-full bg-accent/10 blur-3xl" />
+          <div className="relative">
+            <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-accent mb-3">Guided Workflows</p>
+            <h1 className="text-3xl md:text-4xl text-slate-900 mb-3" style={{ fontFamily: "var(--font-display)" }}>
+              Content Blueprints
+            </h1>
+            <p className="text-slate-500 max-w-xl leading-relaxed">
+              End-to-end workflows that chain the right tools in the right order. Pick a blueprint, follow the steps, and ship complete content — no guesswork.
+            </p>
+          </div>
+        </div>
+
+        {/* Blueprint cards */}
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {BLUEPRINTS.map((bp) => (
+            <BlueprintCard key={bp.id} blueprint={bp} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BlueprintCard({ blueprint: bp }: { blueprint: Blueprint }) {
+  const firstTool = bp.steps[0];
+
+  return (
+    <div className={`shell-panel rounded-[2rem] p-6 flex flex-col gap-5 bg-gradient-to-br ${bp.color} border`}>
+      <div>
+        <div className={`inline-flex items-center gap-2 mb-3 ${bp.accent}`}>
+          {bp.icon}
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em]">{bp.time}</span>
+        </div>
+        <h2 className="text-lg font-semibold text-slate-900 mb-2" style={{ fontFamily: "var(--font-display)" }}>
+          {bp.title}
+        </h2>
+        <p className="text-sm text-slate-500 leading-relaxed">{bp.description}</p>
+      </div>
+
+      {/* Step list */}
+      <ol className="flex flex-col gap-1.5">
+        {bp.steps.map((step, i) => (
+          <li key={step.toolSlug} className="flex items-center gap-2.5">
+            <span className={`shrink-0 w-5 h-5 rounded-full border text-[10px] font-mono font-semibold flex items-center justify-center ${bp.accent} border-current opacity-60`}>
+              {i + 1}
+            </span>
+            <Link
+              href={`/tool/${step.toolSlug}`}
+              className="text-sm text-slate-600 hover:text-slate-900 hover:underline underline-offset-2 transition-colors truncate"
+              title={step.description}
+            >
+              {step.label}
+            </Link>
+          </li>
+        ))}
+      </ol>
+
+      {/* CTA */}
+      <Link
+        href={`/tool/${firstTool.toolSlug}`}
+        className={`mt-auto flex items-center justify-between gap-2 rounded-2xl border px-4 py-3 text-sm font-semibold transition-colors hover:opacity-80 ${bp.accent} border-current bg-white/60`}
+      >
+        <span>Start with {firstTool.label}</span>
+        <ArrowRight className="w-4 h-4 shrink-0" />
+      </Link>
+    </div>
+  );
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { CalendarDays, Search } from "lucide-react";
 import {
   CALENDAR_APPROVAL_STATUSES,
   CALENDAR_APPROVAL_STATUS_LABELS,
@@ -288,6 +289,8 @@ export default function CalendarPage() {
   const [weekOffset, setWeekOffset] = useState(0);
   const [monthOffset, setMonthOffset] = useState(0);
   const [quickRescheduling, setQuickRescheduling] = useState(false);
+  const [editorTab, setEditorTab] = useState<"details" | "brief" | "workflow" | "publishing">("details");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   // When arriving via a "Plan in Calendar" handoff from a keyword research
   // brief, URL params pre-fill the Quick Plan form so the user can schedule
@@ -605,17 +608,16 @@ export default function CalendarPage() {
           <div className="flex items-center justify-between gap-4">
             <div>
               <p className="font-mono text-xs text-accent uppercase tracking-widest">Quick Plan</p>
-              <p className="text-sm text-slate-200 mt-1">Add a topic, assign a tool, and give it a date so the queue stays visible.</p>
-              <p className="text-xs text-muted/60 mt-0.5">Dates are planning guides only — publishing to WordPress is always triggered manually.</p>
+              <p className="text-sm text-slate-200 mt-1">Add a title, pick a tool, and set a date.</p>
             </div>
-            <Link href={buildToolHref(createDraft)} className="text-sm border border-border rounded-2xl px-4 py-2.5 text-slate-700 hover:text-slate-900 hover:border-accent/40 transition-colors">
-              Open Tool Draft
+            <Link href={buildToolHref(createDraft)} className="text-sm border border-border rounded-2xl px-4 py-2.5 text-slate-700 hover:text-slate-900 hover:border-accent/40 transition-colors shrink-0">
+              Open Tool
             </Link>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_auto_auto] gap-3 items-end">
             <input
-              className={`${inputClassName} md:col-span-2`}
+              className={inputClassName}
               placeholder="Content title or angle"
               value={createDraft.title}
               onChange={(event) => setCreateDraft((current) => ({ ...current, title: event.target.value }))}
@@ -635,92 +637,97 @@ export default function CalendarPage() {
               value={createDraft.scheduled_for}
               onChange={(event) => setCreateDraft((current) => ({ ...current, scheduled_for: event.target.value }))}
             />
-            <input
-              type="date"
-              className={inputClassName}
-              value={createDraft.review_due_at}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, review_due_at: event.target.value }))}
-            />
-            <input
-              className={inputClassName}
-              placeholder="Keywords"
-              value={createDraft.keywords}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, keywords: event.target.value }))}
-            />
-            <input
-              className={inputClassName}
-              placeholder="Audience"
-              value={createDraft.audience}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, audience: event.target.value }))}
-            />
-            <select
-              className={inputClassName}
-              value={createDraft.status}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, status: event.target.value as CalendarEntryStatus }))}
-            >
-              {CALENDAR_STATUSES.map((status) => (
-                <option key={status} value={status}>{CALENDAR_STATUS_LABELS[status]}</option>
-              ))}
-            </select>
             <button
               onClick={handleCreateEntry}
               disabled={creating || !createDraft.title.trim()}
-              className="bg-accent text-white font-semibold px-4 py-3 rounded-2xl text-sm hover:bg-accent-dim transition-colors disabled:opacity-50"
+              className="bg-accent text-white font-semibold px-5 py-3 rounded-2xl text-sm hover:bg-accent-dim transition-colors disabled:opacity-50 whitespace-nowrap"
             >
-              {creating ? "Adding..." : "Add to Calendar"}
+              {creating ? "Adding..." : "Add"}
             </button>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-            <input
-              className={inputClassName}
-              placeholder="Owner"
-              value={createDraft.owner}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, owner: event.target.value }))}
-            />
-            <input
-              className={inputClassName}
-              placeholder="Reviewer"
-              value={createDraft.reviewer}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, reviewer: event.target.value }))}
-            />
-            <select
-              className={inputClassName}
-              value={createDraft.approval_status}
-              onChange={(event) => setCreateDraft((current) => ({
-                ...current,
-                approval_status: event.target.value as CalendarApprovalStatus,
-                blocked_reason: event.target.value === "blocked" ? current.blocked_reason : "",
-              }))}
-            >
-              {CALENDAR_APPROVAL_STATUSES.map((status) => (
-                <option key={status} value={status}>{CALENDAR_APPROVAL_STATUS_LABELS[status]}</option>
-              ))}
-            </select>
-            <input
-              className={`${inputClassName} disabled:opacity-50`}
-              placeholder="Blocked reason"
-              value={createDraft.blocked_reason}
-              disabled={createDraft.approval_status !== "blocked"}
-              onChange={(event) => setCreateDraft((current) => ({ ...current, blocked_reason: event.target.value }))}
-            />
-          </div>
+          <button
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            <span className={`transition-transform ${showAdvanced ? "rotate-90" : ""}`}>›</span>
+            {showAdvanced ? "Hide" : "Advanced"} options
+          </button>
 
-          <textarea
-            className={`${inputClassName} resize-none`}
-            rows={2}
-            placeholder="Brief or planning note"
-            value={createDraft.brief}
-            onChange={(event) => setCreateDraft((current) => ({ ...current, brief: event.target.value }))}
-          />
-
-          <textarea
-            className={`${inputClassName} resize-none`}
-            rows={4}
-            placeholder="Checklist items, one per line"
-            value={createDraft.checklist_text}
-            onChange={(event) => setCreateDraft((current) => ({ ...current, checklist_text: event.target.value }))}
-          />
+          {showAdvanced && (
+            <div className="space-y-3 pt-1">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <input
+                  className={inputClassName}
+                  placeholder="Keywords"
+                  value={createDraft.keywords}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, keywords: event.target.value }))}
+                />
+                <input
+                  className={inputClassName}
+                  placeholder="Audience"
+                  value={createDraft.audience}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, audience: event.target.value }))}
+                />
+                <input
+                  type="date"
+                  className={inputClassName}
+                  value={createDraft.review_due_at}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, review_due_at: event.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+                <input
+                  className={inputClassName}
+                  placeholder="Owner"
+                  value={createDraft.owner}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, owner: event.target.value }))}
+                />
+                <input
+                  className={inputClassName}
+                  placeholder="Reviewer"
+                  value={createDraft.reviewer}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, reviewer: event.target.value }))}
+                />
+                <select
+                  className={inputClassName}
+                  value={createDraft.status}
+                  onChange={(event) => setCreateDraft((current) => ({ ...current, status: event.target.value as CalendarEntryStatus }))}
+                >
+                  {CALENDAR_STATUSES.map((status) => (
+                    <option key={status} value={status}>{CALENDAR_STATUS_LABELS[status]}</option>
+                  ))}
+                </select>
+                <select
+                  className={inputClassName}
+                  value={createDraft.approval_status}
+                  onChange={(event) => setCreateDraft((current) => ({
+                    ...current,
+                    approval_status: event.target.value as CalendarApprovalStatus,
+                    blocked_reason: event.target.value === "blocked" ? current.blocked_reason : "",
+                  }))}
+                >
+                  {CALENDAR_APPROVAL_STATUSES.map((status) => (
+                    <option key={status} value={status}>{CALENDAR_APPROVAL_STATUS_LABELS[status]}</option>
+                  ))}
+                </select>
+              </div>
+              <textarea
+                className={`${inputClassName} resize-none`}
+                rows={2}
+                placeholder="Brief or planning note"
+                value={createDraft.brief}
+                onChange={(event) => setCreateDraft((current) => ({ ...current, brief: event.target.value }))}
+              />
+              <textarea
+                className={`${inputClassName} resize-none`}
+                rows={3}
+                placeholder="Checklist items, one per line"
+                value={createDraft.checklist_text}
+                onChange={(event) => setCreateDraft((current) => ({ ...current, checklist_text: event.target.value }))}
+              />
+            </div>
+          )}
         </section>
 
         {(error || message) && (
@@ -856,7 +863,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && (statusFilter !== "all" || toolFilter !== "all" || publishIntentFilter !== "all") && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🔍</div>
+                    <Search className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No items match the active filters.</p>
                     <button
                       onClick={() => { setStatusFilter("all"); setToolFilter("all"); setPublishIntentFilter("all"); }}
@@ -869,7 +876,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && statusFilter === "all" && toolFilter === "all" && publishIntentFilter === "all" && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🗓️</div>
+                    <CalendarDays className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No planned content yet.</p>
                     <p className="text-xs text-slate-500 mt-1">Add your first scheduled item above to start building the queue.</p>
                   </div>
@@ -967,7 +974,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && (statusFilter !== "all" || toolFilter !== "all" || publishIntentFilter !== "all") && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🔍</div>
+                    <Search className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No items match the active filters.</p>
                     <button
                       onClick={() => { setStatusFilter("all"); setToolFilter("all"); setPublishIntentFilter("all"); }}
@@ -980,7 +987,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && statusFilter === "all" && toolFilter === "all" && publishIntentFilter === "all" && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🗓️</div>
+                    <CalendarDays className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No planned content yet.</p>
                     <p className="text-xs text-slate-500 mt-1">Add your first scheduled item above to start building the queue.</p>
                   </div>
@@ -1097,7 +1104,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && (statusFilter !== "all" || toolFilter !== "all" || publishIntentFilter !== "all") && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🔍</div>
+                    <Search className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No items match the active filters.</p>
                     <button
                       onClick={() => { setStatusFilter("all"); setToolFilter("all"); setPublishIntentFilter("all"); }}
@@ -1110,7 +1117,7 @@ export default function CalendarPage() {
 
                 {!loading && rows.length === 0 && statusFilter === "all" && toolFilter === "all" && publishIntentFilter === "all" && (
                   <div className="p-6 text-center">
-                    <div className="text-4xl opacity-30 mb-3">🗓️</div>
+                    <CalendarDays className="w-8 h-8 opacity-30 text-slate-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-400">No planned content yet.</p>
                     <p className="text-xs text-slate-500 mt-1">Add your first scheduled item above to start building the queue.</p>
                   </div>
@@ -1217,230 +1224,255 @@ export default function CalendarPage() {
             {!selectedEntry || !editorDraft ? (
               <div className="flex-1 flex items-center justify-center text-center p-8">
                 <EmptyState
-                  icon="🗓️"
+                  icon={<CalendarDays />}
                   eyebrow="Planned Item"
                   description="Select a calendar entry to update scheduling details, refine the brief, or jump into the assigned writing tool."
                 />
               </div>
             ) : (
               <>
-                <div className="px-6 py-4 border-b border-white/5 flex items-center justify-between gap-4">
-                  <div>
+                {/* Editor header */}
+                <div className="px-5 py-4 border-b border-white/5 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
                     <p className="font-mono text-xs text-accent uppercase tracking-widest">Planned Item</p>
-                    <h2 className="text-slate-900 text-lg mt-1">{selectedEntry.title}</h2>
+                    <h2 className="text-slate-900 text-base font-semibold mt-0.5 truncate">{selectedEntry.title}</h2>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 shrink-0">
                     <Link
                       href={buildToolHref(editorDraft)}
-                      className="shell-hover-lift text-sm border border-border rounded-2xl px-3 py-2 text-slate-700 hover:text-slate-900 hover:border-accent/40 transition-colors"
+                      className="text-sm border border-border rounded-xl px-3 py-1.5 text-slate-700 hover:text-slate-900 hover:border-accent/40 transition-colors"
                     >
                       Open Tool
                     </Link>
                     <button
                       onClick={handleDeleteSelected}
                       disabled={deleting}
-                      className="text-sm border border-red-200 rounded-lg px-3 py-2 text-red-600 hover:text-red-700 hover:border-red-300 transition-colors disabled:opacity-50"
+                      className="text-sm border border-red-200 rounded-xl px-3 py-1.5 text-red-600 hover:border-red-300 transition-colors disabled:opacity-50"
                     >
-                      {deleting ? "Deleting..." : "Delete"}
+                      {deleting ? "…" : "Delete"}
                     </button>
                     <button
                       onClick={handleSaveSelected}
                       disabled={saving}
-                      className="shell-hover-lift bg-accent text-white font-semibold px-4 py-2 rounded-2xl text-sm hover:bg-accent-dim transition-colors disabled:opacity-50"
+                      className="bg-accent text-white font-semibold px-4 py-1.5 rounded-xl text-sm hover:bg-accent-dim transition-colors disabled:opacity-50"
                     >
-                      {saving ? "Saving..." : "Save Changes"}
+                      {saving ? "Saving…" : "Save"}
                     </button>
                   </div>
                 </div>
 
-                <div className="p-6 flex-1 overflow-y-auto space-y-5">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Title</label>
-                      <input
-                        className={inputClassName}
-                        value={editorDraft.title}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, title: event.target.value } : current)}
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Tool</label>
-                      <select
-                        className={inputClassName}
-                        value={editorDraft.tool_slug}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, tool_slug: event.target.value } : current)}
-                      >
-                        {TOOLS.map((tool) => (
-                          <option key={tool.slug} value={tool.slug}>{tool.icon} {tool.name}</option>
-                        ))}
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Status</label>
-                      <select
-                        className={inputClassName}
-                        value={editorDraft.status}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, status: event.target.value as CalendarEntryStatus } : current)}
-                      >
-                        {CALENDAR_STATUSES.map((status) => (
-                          <option key={status} value={status}>{CALENDAR_STATUS_LABELS[status]}</option>
-                        ))}
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Scheduled For</label>
-                      <input
-                        type="date"
-                        className={inputClassName}
-                        value={editorDraft.scheduled_for}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, scheduled_for: event.target.value } : current)}
-                      />
-                      <p className="text-xs text-muted/60 mt-1">Editorial planning date. Also used as the WordPress publish date when publish intent is set to &ldquo;Schedule&rdquo;. Publishing is always triggered manually.</p>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Review Due</label>
-                      <input
-                        type="date"
-                        className={inputClassName}
-                        value={editorDraft.review_due_at}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, review_due_at: event.target.value } : current)}
-                      />
-                      <p className="text-xs text-muted/60 mt-1">Separate sign-off deadline for editorial review. This does not change publish timing.</p>
-                    </div>
-                  </div>
+                {/* Tab bar */}
+                <div className="flex border-b border-white/5 px-2 pt-1 shrink-0">
+                  {(["details", "brief", "workflow", "publishing"] as const).map((tab) => (
+                    <button
+                      key={tab}
+                      onClick={() => setEditorTab(tab)}
+                      className={`px-3 py-2 text-xs font-mono uppercase tracking-[0.16em] rounded-t-xl transition-colors ${
+                        editorTab === tab
+                          ? "bg-white/[0.04] text-slate-900 border-b-2 border-accent"
+                          : "text-slate-500 hover:text-slate-700"
+                      }`}
+                    >
+                      {tab === "brief" ? "Brief & Notes" : tab.charAt(0).toUpperCase() + tab.slice(1)}
+                    </button>
+                  ))}
+                </div>
 
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Keywords</label>
-                      <input
-                        className={inputClassName}
-                        placeholder="primary keyword, cluster, search phrase"
-                        value={editorDraft.keywords}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, keywords: event.target.value } : current)}
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Audience</label>
-                      <input
-                        className={inputClassName}
-                        placeholder="who this piece is for"
-                        value={editorDraft.audience}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, audience: event.target.value } : current)}
-                      />
-                    </div>
-                  </div>
+                {/* Tab content */}
+                <div className="p-5 flex-1 overflow-y-auto space-y-4">
 
-                  <div className="bg-card-alt border border-border rounded-xl p-5 space-y-4 shadow-card-inset">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="font-mono text-xs text-muted uppercase tracking-wider">Workflow</p>
-                      <span className={`text-[11px] font-mono border rounded-full px-2.5 py-1 ${getApprovalBadgeClass(editorDraft.approval_status)}`}>
-                        {CALENDAR_APPROVAL_STATUS_LABELS[editorDraft.approval_status]}
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  {/* Details tab */}
+                  {editorTab === "details" && (
+                    <>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="md:col-span-2">
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Title</label>
+                          <input
+                            className={inputClassName}
+                            value={editorDraft.title}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, title: event.target.value } : current)}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Tool</label>
+                          <select
+                            className={inputClassName}
+                            value={editorDraft.tool_slug}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, tool_slug: event.target.value } : current)}
+                          >
+                            {TOOLS.map((tool) => (
+                              <option key={tool.slug} value={tool.slug}>{tool.icon} {tool.name}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Status</label>
+                          <select
+                            className={inputClassName}
+                            value={editorDraft.status}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, status: event.target.value as CalendarEntryStatus } : current)}
+                          >
+                            {CALENDAR_STATUSES.map((status) => (
+                              <option key={status} value={status}>{CALENDAR_STATUS_LABELS[status]}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Scheduled For</label>
+                          <input
+                            type="date"
+                            className={inputClassName}
+                            value={editorDraft.scheduled_for}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, scheduled_for: event.target.value } : current)}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Review Due</label>
+                          <input
+                            type="date"
+                            className={inputClassName}
+                            value={editorDraft.review_due_at}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, review_due_at: event.target.value } : current)}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Keywords</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="primary keyword, cluster..."
+                            value={editorDraft.keywords}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, keywords: event.target.value } : current)}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Audience</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="who this piece is for"
+                            value={editorDraft.audience}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, audience: event.target.value } : current)}
+                          />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-3 gap-3 pt-1">
+                        <div className="shell-panel-soft rounded-xl p-3">
+                          <p className="font-mono text-[11px] text-slate-500 uppercase tracking-wider">Created</p>
+                          <p className="text-xs text-slate-800 mt-1">{new Date(selectedEntry.created_at).toLocaleString()}</p>
+                        </div>
+                        <div className="shell-panel-soft rounded-xl p-3">
+                          <p className="font-mono text-[11px] text-slate-500 uppercase tracking-wider">Updated</p>
+                          <p className="text-xs text-slate-800 mt-1">{new Date(selectedEntry.updated_at).toLocaleString()}</p>
+                        </div>
+                        <div className="shell-panel-soft rounded-xl p-3">
+                          <p className="font-mono text-[11px] text-slate-500 uppercase tracking-wider">Tool</p>
+                          <p className="text-xs text-slate-800 mt-1">{getToolBySlug(editorDraft.tool_slug)?.name ?? editorDraft.tool_slug}</p>
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {/* Brief & Notes tab */}
+                  {editorTab === "brief" && (
+                    <>
                       <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">Owner</label>
-                        <input
-                          className={inputClassName}
-                          placeholder="Who owns delivery"
-                          value={editorDraft.owner}
-                          onChange={(event) => setEditorDraft((current) => current ? { ...current, owner: event.target.value } : current)}
+                        <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Brief</label>
+                        <textarea
+                          className={`${inputClassName} resize-none`}
+                          rows={4}
+                          placeholder="Short description of the angle, hook, or desired outcome"
+                          value={editorDraft.brief}
+                          onChange={(event) => setEditorDraft((current) => current ? { ...current, brief: event.target.value } : current)}
                         />
                       </div>
                       <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">Reviewer</label>
-                        <input
-                          className={inputClassName}
-                          placeholder="Who signs off"
-                          value={editorDraft.reviewer}
-                          onChange={(event) => setEditorDraft((current) => current ? { ...current, reviewer: event.target.value } : current)}
+                        <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Notes</label>
+                        <textarea
+                          className={`${inputClassName} resize-none`}
+                          rows={7}
+                          placeholder="Research notes, links, CTA ideas, internal reminders..."
+                          value={editorDraft.notes}
+                          onChange={(event) => setEditorDraft((current) => current ? { ...current, notes: event.target.value } : current)}
                         />
                       </div>
                       <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">Approval Status</label>
-                        <select
-                          className={inputClassName}
-                          value={editorDraft.approval_status}
-                          onChange={(event) => setEditorDraft((current) => current ? {
-                            ...current,
-                            approval_status: event.target.value as CalendarApprovalStatus,
-                            blocked_reason: event.target.value === "blocked" ? current.blocked_reason : "",
-                          } : current)}
-                        >
-                          {CALENDAR_APPROVAL_STATUSES.map((status) => (
-                            <option key={status} value={status}>{CALENDAR_APPROVAL_STATUS_LABELS[status]}</option>
-                          ))}
-                        </select>
+                        <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Checklist</label>
+                        <textarea
+                          className={`${inputClassName} resize-none`}
+                          rows={5}
+                          placeholder="[ ] Draft outline&#10;[ ] Final review&#10;[x] Keyword research done"
+                          value={editorDraft.checklist_text}
+                          onChange={(event) => setEditorDraft((current) => current ? { ...current, checklist_text: event.target.value } : current)}
+                        />
+                        <p className="text-xs text-muted/60 mt-1">Use <code>[ ]</code> and <code>[x]</code> to track completion.</p>
                       </div>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">Blocked Reason</label>
-                      <textarea
-                        className={`${inputClassName} resize-none disabled:opacity-50`}
-                        rows={3}
-                        disabled={editorDraft.approval_status !== "blocked"}
-                        placeholder="Missing source material, awaiting sign-off, legal review, or another blocker"
-                        value={editorDraft.blocked_reason}
-                        onChange={(event) => setEditorDraft((current) => current ? { ...current, blocked_reason: event.target.value } : current)}
-                      />
-                      <p className="text-xs text-muted/60 mt-1">Use this when a piece cannot move forward yet. Clearing the blocked status also clears the reason on save.</p>
-                    </div>
-                  </div>
+                    </>
+                  )}
 
-                  <div>
-                    <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Brief</label>
-                    <textarea
-                      className={`${inputClassName} resize-none`}
-                      rows={4}
-                      placeholder="Short description of the angle, hook, or desired outcome"
-                      value={editorDraft.brief}
-                      onChange={(event) => setEditorDraft((current) => current ? { ...current, brief: event.target.value } : current)}
-                    />
-                  </div>
+                  {/* Workflow tab */}
+                  {editorTab === "workflow" && (
+                    <>
+                      <div className="flex items-center justify-between gap-3 mb-1">
+                        <p className="text-xs font-mono text-slate-500 uppercase tracking-wider">Approval</p>
+                        <span className={`text-[11px] font-mono border rounded-full px-2.5 py-1 ${getApprovalBadgeClass(editorDraft.approval_status)}`}>
+                          {CALENDAR_APPROVAL_STATUS_LABELS[editorDraft.approval_status]}
+                        </span>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Owner</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="Who owns delivery"
+                            value={editorDraft.owner}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, owner: event.target.value } : current)}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Reviewer</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="Who signs off"
+                            value={editorDraft.reviewer}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, reviewer: event.target.value } : current)}
+                          />
+                        </div>
+                        <div className="md:col-span-2">
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Approval Status</label>
+                          <select
+                            className={inputClassName}
+                            value={editorDraft.approval_status}
+                            onChange={(event) => setEditorDraft((current) => current ? {
+                              ...current,
+                              approval_status: event.target.value as CalendarApprovalStatus,
+                              blocked_reason: event.target.value === "blocked" ? current.blocked_reason : "",
+                            } : current)}
+                          >
+                            {CALENDAR_APPROVAL_STATUSES.map((status) => (
+                              <option key={status} value={status}>{CALENDAR_APPROVAL_STATUS_LABELS[status]}</option>
+                            ))}
+                          </select>
+                        </div>
+                        {editorDraft.approval_status === "blocked" && (
+                          <div className="md:col-span-2">
+                            <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Blocked Reason</label>
+                            <textarea
+                              className={`${inputClassName} resize-none`}
+                              rows={3}
+                              placeholder="Missing source material, awaiting sign-off, legal review..."
+                              value={editorDraft.blocked_reason}
+                              onChange={(event) => setEditorDraft((current) => current ? { ...current, blocked_reason: event.target.value } : current)}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
 
-                  <div>
-                    <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Notes</label>
-                    <textarea
-                      className={`${inputClassName} resize-none`}
-                      rows={8}
-                      placeholder="Research notes, links, CTA ideas, internal reminders, or production steps"
-                      value={editorDraft.notes}
-                      onChange={(event) => setEditorDraft((current) => current ? { ...current, notes: event.target.value } : current)}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Checklist</label>
-                    <textarea
-                      className={`${inputClassName} resize-none`}
-                      rows={6}
-                      placeholder="One line per production step, asset, or approval task"
-                      value={editorDraft.checklist_text}
-                      onChange={(event) => setEditorDraft((current) => current ? { ...current, checklist_text: event.target.value } : current)}
-                    />
-                    <p className="text-xs text-muted/60 mt-1">Use lines like [ ] Draft outline or [x] Final review to preserve completion state.</p>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="shell-panel-soft rounded-2xl p-4">
-                      <p className="font-mono text-xs text-slate-500 uppercase tracking-wider">Created</p>
-                      <p className="text-sm text-slate-900 mt-2">{new Date(selectedEntry.created_at).toLocaleString()}</p>
-                    </div>
-                    <div className="shell-panel-soft rounded-2xl p-4">
-                      <p className="font-mono text-xs text-slate-500 uppercase tracking-wider">Last Updated</p>
-                      <p className="text-sm text-slate-900 mt-2">{new Date(selectedEntry.updated_at).toLocaleString()}</p>
-                    </div>
-                    <div className="shell-panel-soft rounded-2xl p-4">
-                      <p className="font-mono text-xs text-slate-500 uppercase tracking-wider">Current Tool</p>
-                      <p className="text-sm text-slate-900 mt-2">{getToolBySlug(editorDraft.tool_slug)?.name ?? editorDraft.tool_slug}</p>
-                    </div>
-                  </div>
-
-                  <div className="bg-card-alt border border-border rounded-xl p-5 space-y-3 shadow-card-inset">
-                    <p className="font-mono text-xs text-muted uppercase tracking-wider">Publishing</p>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Publishing tab */}
+                  {editorTab === "publishing" && (
+                    <>
                       <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">Publish Intent</label>
+                        <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Publish Intent</label>
                         <select
                           className={inputClassName}
                           value={selectedEntry.publish_intent}
@@ -1453,9 +1485,7 @@ export default function CalendarPage() {
                                 body: JSON.stringify({ ...toPayload(editorDraft), publish_intent: newIntent }),
                               });
                               const data = await res.json();
-                              if (!res.ok) {
-                                throw new Error(data.error || "Failed to update publish intent");
-                              }
+                              if (!res.ok) throw new Error(data.error || "Failed to update publish intent");
                               await fetchCalendar(selectedEntry.id);
                             } catch (intentError) {
                               setError(intentError instanceof Error ? intentError.message : "Failed to update publish intent");
@@ -1463,47 +1493,48 @@ export default function CalendarPage() {
                           }}
                         >
                           <option value="draft">Draft — send to WordPress as draft</option>
-                          <option value="publish">Publish — make live on WordPress immediately</option>
-                          <option value="schedule">Schedule — queue on WordPress using the planned date (WordPress controls timing)</option>
+                          <option value="publish">Publish — make live immediately</option>
+                          <option value="schedule">Schedule — use planned date (WordPress controls timing)</option>
                         </select>
-                        <p className="text-xs text-muted/60 mt-1">Controls what happens on the next manual publish action. Scheduling hands the publish date to WordPress — the app does not auto-publish.</p>
+                        <p className="text-xs text-muted/60 mt-1">Publishing is always triggered manually from History.</p>
                       </div>
+
                       <div>
-                        <p className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">WordPress Status</p>
+                        <p className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">WordPress Status</p>
                         {selectedEntry.wp_post_id ? (
-                          <div className="space-y-1">
-                            <span className="inline-block text-xs font-mono border border-green-200 text-green-600 rounded px-2 py-1 bg-green-50">
-                              Post #{selectedEntry.wp_post_id} synced
-                            </span>
-                          </div>
+                          <span className="inline-block text-xs font-mono border border-green-200 text-green-600 rounded-lg px-3 py-1.5 bg-green-50">
+                            Post #{selectedEntry.wp_post_id} synced
+                          </span>
                         ) : (
                           <p className="text-sm text-muted/60">Not yet published to WordPress</p>
                         )}
                       </div>
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">WP Category IDs</label>
-                        <input
-                          className={inputClassName}
-                          placeholder="1, 5, 12"
-                          value={editorDraft.wp_category}
-                          onChange={(event) => setEditorDraft((current) => current ? { ...current, wp_category: event.target.value } : current)}
-                        />
-                        <p className="text-xs text-muted/60 mt-1">Comma-separated WordPress category IDs sent on publish.</p>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">WP Category IDs</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="1, 5, 12"
+                            value={editorDraft.wp_category}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, wp_category: event.target.value } : current)}
+                          />
+                          <p className="text-xs text-muted/60 mt-1">Comma-separated category IDs.</p>
+                        </div>
+                        <div>
+                          <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">WP Tag IDs</label>
+                          <input
+                            className={inputClassName}
+                            placeholder="3, 7"
+                            value={editorDraft.wp_tags}
+                            onChange={(event) => setEditorDraft((current) => current ? { ...current, wp_tags: event.target.value } : current)}
+                          />
+                          <p className="text-xs text-muted/60 mt-1">Comma-separated tag IDs.</p>
+                        </div>
                       </div>
-                      <div>
-                        <label className="block text-xs font-mono text-muted uppercase tracking-wider mb-1.5">WP Tag IDs</label>
-                        <input
-                          className={inputClassName}
-                          placeholder="3, 7"
-                          value={editorDraft.wp_tags}
-                          onChange={(event) => setEditorDraft((current) => current ? { ...current, wp_tags: event.target.value } : current)}
-                        />
-                        <p className="text-xs text-muted/60 mt-1">Comma-separated WordPress tag IDs sent on publish.</p>
-                      </div>
-                    </div>
-                  </div>
+                    </>
+                  )}
+
                 </div>
               </>
             )}

--- a/app/customization/knowledge/page.tsx
+++ b/app/customization/knowledge/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Library, Plus, Trash2, FileText, Link as LinkIcon } from "lucide-react";
 import { PageHeader, SectionCard, EmptyState, SurfaceNotice } from "@/components/DashboardPrimitives";
+import { useKnowledgeBase } from "@/lib/use-knowledge-base";
 
 type SourceType = "text" | "url";
 
@@ -15,16 +16,8 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
-interface KnowledgeEntry {
-  id: string;
-  title: string;
-  type: SourceType;
-  content: string;
-  createdAt: string;
-}
-
 export default function KnowledgePage() {
-  const [entries, setEntries] = useState<KnowledgeEntry[]>([]);
+  const { entries, addEntry, removeEntry } = useKnowledgeBase();
   const [showForm, setShowForm] = useState(false);
   const [sourceType, setSourceType] = useState<SourceType>("text");
   const [title, setTitle] = useState("");
@@ -41,22 +34,17 @@ export default function KnowledgePage() {
       return;
     }
     setError(null);
-    const entry: KnowledgeEntry = {
-      id: crypto.randomUUID(),
+    addEntry({
       title: title.trim(),
       type: sourceType,
       content: sourceType === "url" ? new URL(content.trim()).href : content.trim(),
-      createdAt: new Date().toISOString(),
-    };
-    setEntries((prev) => [entry, ...prev]);
+    });
     setTitle("");
     setContent("");
     setShowForm(false);
   };
 
-  const handleDelete = (id: string) => {
-    setEntries((prev) => prev.filter((e) => e.id !== id));
-  };
+  const handleDelete = (id: string) => removeEntry(id);
 
   const inputClassName =
     "shell-input w-full rounded-2xl px-3.5 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none transition-colors";

--- a/app/customization/mytone/page.tsx
+++ b/app/customization/mytone/page.tsx
@@ -19,7 +19,7 @@ const SENTENCE_LENGTHS = ["Short & Punchy", "Balanced", "Long & Detailed"];
 const VOICE_TYPES = ["Active", "Passive", "Mixed"];
 
 export default function MyTonePage() {
-  const { config, save, loaded } = useMyTone();
+  const { config, save } = useMyTone();
   const { toast } = useToast();
 
   const [selectedPreset, setSelectedPreset] = useState(config.preset);
@@ -27,17 +27,6 @@ export default function MyTonePage() {
   const [sentenceLength, setSentenceLength] = useState(config.sentenceLength);
   const [voiceType, setVoiceType] = useState(config.voiceType);
   const [customInstructions, setCustomInstructions] = useState(config.customInstructions);
-
-  // Sync local state once localStorage has loaded
-  useEffect(() => {
-    if (loaded) {
-      setSelectedPreset(config.preset);
-      setFormality(config.formality);
-      setSentenceLength(config.sentenceLength);
-      setVoiceType(config.voiceType);
-      setCustomInstructions(config.customInstructions);
-    }
-  }, [loaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSave = () => {
     const next: ToneConfig = { preset: selectedPreset, formality, sentenceLength, voiceType, customInstructions };

--- a/app/customization/mytone/page.tsx
+++ b/app/customization/mytone/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Mic2, Save } from "lucide-react";
 import { PageHeader, SectionCard, SurfaceNotice } from "@/components/DashboardPrimitives";
+import { useMyTone, type ToneConfig } from "@/lib/use-my-tone";
+import { useToast } from "@/components/Toast";
 
 const TONE_PRESETS = [
   { id: "professional", label: "Professional", description: "Clear, authoritative, and polished. Ideal for business and technical content." },
@@ -17,16 +19,30 @@ const SENTENCE_LENGTHS = ["Short & Punchy", "Balanced", "Long & Detailed"];
 const VOICE_TYPES = ["Active", "Passive", "Mixed"];
 
 export default function MyTonePage() {
-  const [selectedPreset, setSelectedPreset] = useState("conversational");
-  const [formality, setFormality] = useState(2);
-  const [sentenceLength, setSentenceLength] = useState(1);
-  const [voiceType, setVoiceType] = useState(0);
-  const [customInstructions, setCustomInstructions] = useState("");
-  const [saved, setSaved] = useState(false);
+  const { config, save, loaded } = useMyTone();
+  const { toast } = useToast();
+
+  const [selectedPreset, setSelectedPreset] = useState(config.preset);
+  const [formality, setFormality] = useState(config.formality);
+  const [sentenceLength, setSentenceLength] = useState(config.sentenceLength);
+  const [voiceType, setVoiceType] = useState(config.voiceType);
+  const [customInstructions, setCustomInstructions] = useState(config.customInstructions);
+
+  // Sync local state once localStorage has loaded
+  useEffect(() => {
+    if (loaded) {
+      setSelectedPreset(config.preset);
+      setFormality(config.formality);
+      setSentenceLength(config.sentenceLength);
+      setVoiceType(config.voiceType);
+      setCustomInstructions(config.customInstructions);
+    }
+  }, [loaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSave = () => {
-    setSaved(true);
-    setTimeout(() => setSaved(false), 3000);
+    const next: ToneConfig = { preset: selectedPreset, formality, sentenceLength, voiceType, customInstructions };
+    save(next);
+    toast("Tone settings saved — applied to all future generations");
   };
 
   const inputClassName =
@@ -147,8 +163,6 @@ export default function MyTonePage() {
               />
             </SectionCard>
 
-            {saved && <SurfaceNotice tone="success">Your tone settings have been saved.</SurfaceNotice>}
-
             <button
               onClick={handleSave}
               className="inline-flex items-center gap-2 bg-accent text-white font-semibold px-5 py-3 rounded-2xl text-sm hover:bg-accent-dim transition-colors"
@@ -164,24 +178,24 @@ export default function MyTonePage() {
               <div className="space-y-3">
                 <div>
                   <p className="text-[11px] font-mono text-slate-500 uppercase tracking-wider mb-1">Preset</p>
-                  <p className="text-white text-sm capitalize">{selectedPreset}</p>
+                  <p className="text-slate-900 text-sm capitalize">{selectedPreset}</p>
                 </div>
                 <div>
                   <p className="text-[11px] font-mono text-slate-500 uppercase tracking-wider mb-1">Formality</p>
-                  <p className="text-white text-sm">{FORMALITY_LEVELS[formality]}</p>
+                  <p className="text-slate-900 text-sm">{FORMALITY_LEVELS[formality]}</p>
                 </div>
                 <div>
                   <p className="text-[11px] font-mono text-slate-500 uppercase tracking-wider mb-1">Sentence Length</p>
-                  <p className="text-white text-sm">{SENTENCE_LENGTHS[sentenceLength]}</p>
+                  <p className="text-slate-900 text-sm">{SENTENCE_LENGTHS[sentenceLength]}</p>
                 </div>
                 <div>
                   <p className="text-[11px] font-mono text-slate-500 uppercase tracking-wider mb-1">Voice</p>
-                  <p className="text-white text-sm">{VOICE_TYPES[voiceType]}</p>
+                  <p className="text-slate-900 text-sm">{VOICE_TYPES[voiceType]}</p>
                 </div>
                 {customInstructions && (
                   <div>
                     <p className="text-[11px] font-mono text-slate-500 uppercase tracking-wider mb-1">Custom Instructions</p>
-                    <p className="text-white text-sm leading-relaxed line-clamp-4">{customInstructions}</p>
+                    <p className="text-slate-900 text-sm leading-relaxed line-clamp-4">{customInstructions}</p>
                   </div>
                 )}
               </div>
@@ -189,10 +203,10 @@ export default function MyTonePage() {
 
             <SectionCard className="space-y-3 h-fit">
               <p className="font-mono text-xs text-slate-500 uppercase tracking-wider">How it works</p>
-              <div className="space-y-2 text-sm text-slate-400">
-                <p>Your tone profile is applied automatically when you generate content with any tool.</p>
-                <p>You can override the tone on individual tools without changing your global settings.</p>
-                <p>Custom instructions are appended to every prompt as system-level guidance.</p>
+              <div className="space-y-2 text-sm text-slate-500">
+                <p>Your tone profile is injected into every generation automatically — no need to set it per-tool.</p>
+                <p>Custom instructions are appended to the system prompt for every request.</p>
+                <p>Settings are stored in your browser and travel with you across sessions.</p>
               </div>
             </SectionCard>
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@
   --color-panel-soft: #f8fafc;
   --color-border: #d7dee7;
   --color-copy: #0f172a;
-  --color-copy-soft: #64748b;
+  --color-copy-soft: #475569;
 }
 
 * {
@@ -269,7 +269,7 @@ body::after {
 .shell-main .shell-panel .text-slate-500,
 .shell-main .shell-panel-soft .text-slate-500,
 .shell-main .shell-stat-card .text-slate-500 {
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .shell-main .text-white\/90 {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = "force-dynamic";
 
 import { useEffect, useState, useCallback, useMemo, Suspense } from "react";
 import Link from "next/link";
+import { Clock } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import type { HistoryFolderSummary, HistoryRow, HistoryTagSummary } from "@/lib/db";
 import { TOOLS } from "@/lib/tools";
@@ -1855,7 +1856,7 @@ function HistoryPageContent() {
           {!selected ? (
             <div className="flex flex-col items-center justify-center h-full text-center">
               <EmptyState
-                icon="🕒"
+                icon={<Clock />}
                 eyebrow="Detail View"
                 description="Select a saved generation from the list to inspect metadata, manage draft status, and review the full output."
               />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { useSession, signOut, SessionProvider } from "next-auth/react";
+import { ToastProvider } from "@/components/Toast";
 import {
   BarChart3,
   CalendarRange,
@@ -14,6 +15,7 @@ import {
   HelpCircle,
   History,
   Home,
+  Layers,
   Library,
   LogOut,
   Menu,
@@ -22,22 +24,14 @@ import {
   SlidersHorizontal,
   Sparkles,
   Users,
+  Wrench,
   X,
 } from "lucide-react";
-import { TOOLS, getAllCategories } from "@/lib/tools";
-
-const CATEGORY_ICONS: Record<string, string> = {
-  "Content Creation": "✍️",
-  "Ideas & Planning": "💡",
-  "SEO & Keywords": "🔍",
-  "Editing & Rewriting": "🔄",
-  "Social Media": "📱",
-  "Email & Marketing": "📣",
-  "Video Content": "🎬",
-};
 
 const PRIMARY_NAV = [
   { href: "/", label: "Dashboard", icon: Home },
+  { href: "/tools", label: "Tools", icon: Wrench },
+  { href: "/blueprint", label: "Blueprints", icon: Layers },
   { href: "/seo", label: "SEO Workspace", icon: BarChart3 },
   { href: "/history", label: "History", icon: History },
   { href: "/calendar", label: "Calendar", icon: CalendarRange },
@@ -101,13 +95,9 @@ function SidebarUserCard() {
 
 function Sidebar() {
   const pathname = usePathname();
-  const categories = getAllCategories();
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [customizationOpen, setCustomizationOpen] = useState(true);
   const [mobileOpen, setMobileOpen] = useState(false);
 
-  const toggle = (cat: string) =>
-    setCollapsed((prev) => ({ ...prev, [cat]: !prev[cat] }));
   const closeMobile = () => setMobileOpen(false);
 
   const navigationContent = (
@@ -140,7 +130,10 @@ function Sidebar() {
         <div className="space-y-1.5">
           {PRIMARY_NAV.map((item) => {
             const Icon = item.icon;
-            const active = pathname === item.href;
+            const active =
+              item.href === "/"
+                ? pathname === "/"
+                : pathname === item.href || pathname.startsWith(item.href + "/");
 
             return (
               <Link
@@ -204,59 +197,6 @@ function Sidebar() {
           )}
         </div>
 
-        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-3">
-          <div className="flex items-center justify-between px-2 pb-2">
-            <p className="text-[11px] font-mono tracking-[0.24em] uppercase text-slate-400">
-              Tool Library
-            </p>
-            <span className="text-[11px] text-slate-400">{TOOLS.length}</span>
-          </div>
-
-          <div className="space-y-1">
-            {categories.map((cat) => {
-              const tools = TOOLS.filter((t) => t.category === cat);
-              const isOpen = !collapsed[cat];
-
-              return (
-                <div key={cat} className="rounded-2xl border border-white/[0.06] bg-black/10 overflow-hidden">
-                  <button
-                    onClick={() => toggle(cat)}
-                    className="w-full flex items-center justify-between px-4 py-3 text-[11px] font-mono tracking-[0.18em] text-slate-300 hover:text-white uppercase transition-colors"
-                  >
-                    <span className="flex items-center gap-2.5 min-w-0">
-                      <span className="text-base shrink-0">{CATEGORY_ICONS[cat] || "🔧"}</span>
-                      <span className="truncate">{cat}</span>
-                    </span>
-                    {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-                  </button>
-
-                  {isOpen && (
-                    <div className="px-2 pb-2 space-y-1">
-                      {tools.map((tool) => {
-                        const active = pathname === `/tool/${tool.slug}`;
-                        return (
-                          <Link
-                            key={tool.slug}
-                            href={`/tool/${tool.slug}`}
-                            onClick={closeMobile}
-                            className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors ${
-                              active
-                                ? "bg-white/10 text-white border border-white/10"
-                                : "text-slate-300 border border-transparent hover:text-white hover:bg-white/[0.04]"
-                            }`}
-                          >
-                            <span className="text-base leading-none">{tool.icon}</span>
-                            <span className="truncate">{tool.name}</span>
-                          </Link>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
       </nav>
 
       <SidebarUserCard />
@@ -313,8 +253,10 @@ export default function RootLayout({
     <html lang="en">
       <body className="app-shell flex min-h-screen">
         <SessionProvider>
-          <Sidebar />
-          <main className="shell-main flex-1 overflow-y-auto pt-16 lg:pt-0">{children}</main>
+          <ToastProvider>
+            <Sidebar />
+            <main className="shell-main flex-1 overflow-y-auto pt-16 lg:pt-0">{children}</main>
+          </ToastProvider>
         </SessionProvider>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -57,6 +57,22 @@ function LoginContent() {
           <p className="text-xs text-center text-slate-400">
             Access is restricted. Your account will be reviewed by an admin before you can use the workspace.
           </p>
+
+          {process.env.NODE_ENV === "development" && (
+            <>
+              <div className="relative flex items-center gap-3">
+                <div className="flex-1 h-px bg-slate-200" />
+                <span className="text-xs text-slate-400 shrink-0">dev only</span>
+                <div className="flex-1 h-px bg-slate-200" />
+              </div>
+              <button
+                onClick={() => signIn("dev-login", { callbackUrl })}
+                className="w-full flex items-center justify-center gap-2 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-600 hover:border-accent/50 hover:text-accent transition-all"
+              >
+                Skip auth — Dev login
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,30 +2,16 @@ import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDb } from "@/lib/db";
-import { TOOLS, getAllCategories } from "@/lib/tools";
-import { STARTER_TEMPLATES, WORKFLOW_PRESETS } from "@/lib/workflow-presets";
+import { TOOLS } from "@/lib/tools";
+import {
+  ArrowRight,
+  CalendarDays,
+  History,
+  PenLine,
+  AlertTriangle,
+  Users,
+} from "lucide-react";
 import SeoScoreTrendCard from "@/components/SeoScoreTrendCard";
-
-const CATEGORY_ICONS: Record<string, string> = {
-  "Content Creation": "✍️",
-  "Ideas & Planning": "💡",
-  "SEO & Keywords": "🔍",
-  "Editing & Rewriting": "🔄",
-  "Social Media": "📱",
-  "Email & Marketing": "📣",
-  "Video Content": "🎬",
-};
-
-const SEO_PRESET_DEFAULTS: Record<string, { stage: string; keyword: string }> = {
-  "idea-to-ranked-post": { stage: "Idea", keyword: "developer productivity" },
-  "youtube-repurpose-loop": { stage: "Drafting", keyword: "content repurposing" },
-  "refresh-existing-content": { stage: "Optimization", keyword: "content refresh" },
-};
-
-function getSeoWorkspacePresetHref(presetId: string): string {
-  const defaults = SEO_PRESET_DEFAULTS[presetId] ?? { stage: "Optimization", keyword: "seo workflow" };
-  return `/seo?${new URLSearchParams({ preset: presetId, stage: defaults.stage, keyword: defaults.keyword })}`;
-}
 
 function greeting(name: string | null | undefined) {
   const hour = new Date().getHours();
@@ -33,9 +19,10 @@ function greeting(name: string | null | undefined) {
   return name ? `${time}, ${name.split(" ")[0]}` : time;
 }
 
-async function getDashboardStats(isAdmin: boolean) {
+async function getDashboardData(isAdmin: boolean) {
   try {
     const db = getDb();
+
     const recentSaves = (db.prepare(
       "SELECT COUNT(*) as count FROM history WHERE created_at >= datetime('now', '-7 days')"
     ).get() as { count: number }).count;
@@ -53,11 +40,11 @@ async function getDashboardStats(isAdmin: boolean) {
       : 0;
 
     const recentHistory = db.prepare(
-      "SELECT id, title, tool_name, tool_icon, created_at FROM history ORDER BY created_at DESC LIMIT 4"
+      "SELECT id, title, tool_name, tool_icon, created_at FROM history ORDER BY created_at DESC LIMIT 5"
     ).all() as { id: number; title: string; tool_name: string; tool_icon: string; created_at: string }[];
 
     const upcomingItems = db.prepare(
-      "SELECT id, title, scheduled_for, status FROM calendar WHERE scheduled_for >= date('now') AND status != 'published' ORDER BY scheduled_for ASC LIMIT 4"
+      "SELECT id, title, scheduled_for, status FROM calendar WHERE scheduled_for >= date('now') AND status != 'published' ORDER BY scheduled_for ASC LIMIT 5"
     ).all() as { id: number; title: string; scheduled_for: string; status: string }[];
 
     return { recentSaves, todayItems, failedPublishes, pendingUsers, recentHistory, upcomingItems };
@@ -66,257 +53,205 @@ async function getDashboardStats(isAdmin: boolean) {
   }
 }
 
-const QUICK_ACTIONS = [
-  { href: "/calendar", label: "Calendar", title: "Editorial calendar", description: "Plan backlog, schedule approved pieces, and keep publishing dates visible across the team.", icon: "🗓️" },
-  { href: "/history", label: "History", title: "Content archive", description: "Inspect saved generations, reopen drafts, and organise content by folder or tag.", icon: "🕒" },
-  { href: "/seo", label: "SEO", title: "SEO workspace", description: "Run keyword-based checks, track checklist progress, and save SEO signals to each draft.", icon: "📈" },
-  { href: "/automation", label: "Automation", title: "Batch & automation", description: "Monitor reusable jobs, recent runs, and scheduler-ready automation payloads.", icon: "🤖" },
-  { href: "/settings", label: "Settings", title: "WordPress & integrations", description: "Check credentials, confirm draft publishing, and keep the publishing pipeline ready.", icon: "⚙️" },
-];
-
 export default async function Dashboard() {
   const session = await getServerSession(authOptions);
-  const user = session?.user as ({ name?: string | null; email?: string | null; image?: string | null; role?: string; status?: string }) | undefined;
+  const user = session?.user as ({ name?: string | null; email?: string | null; image?: string | null; role?: string }) | undefined;
   const isAdmin = user?.role === "admin";
-  const stats = await getDashboardStats(isAdmin);
-  const categories = getAllCategories();
-  const hasAttention = stats.failedPublishes > 0 || (isAdmin && stats.pendingUsers > 0);
+  const data = await getDashboardData(isAdmin);
+
+  const hasAttention = data.failedPublishes > 0 || (isAdmin && data.pendingUsers > 0);
+
+  const stats = [
+    { label: "Saves this week", value: data.recentSaves, sub: "history entries" },
+    { label: "Scheduled today", value: data.todayItems, sub: "on calendar" },
+    { label: "Failed publishes", value: data.failedPublishes, sub: data.failedPublishes > 0 ? "need retry" : "all clear", warn: data.failedPublishes > 0 },
+    { label: "Tools available", value: TOOLS.length, sub: "in library" },
+  ];
 
   return (
-    <div className="p-5 md:p-8 max-w-7xl mx-auto space-y-8">
+    <div className="min-h-screen">
 
-      {/* Personalized hero */}
-      <section className="shell-panel shell-hero-grid rounded-[2rem] p-6 md:p-8 overflow-hidden relative">
-        <div className="absolute right-0 top-0 h-40 w-40 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute bottom-0 right-16 h-28 w-28 rounded-full bg-slate-200/70 blur-2xl" />
-
-        <div className="relative grid gap-8 xl:grid-cols-[1.2fr_0.8fr] items-start">
-          <div>
-            <div className="inline-flex items-center gap-2 shell-badge rounded-full px-3 py-1.5 text-[11px] font-mono tracking-[0.24em] uppercase text-accent mb-5">
-              Editorial Workspace
+      {/* Hero */}
+      <div className="border-b border-slate-200 bg-white px-8 py-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-6">
+            <div>
+              <p className="text-[11px] font-mono tracking-[0.24em] uppercase text-accent mb-1">
+                Editorial Workspace
+              </p>
+              <h1
+                className="text-3xl font-semibold text-slate-900"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                {greeting(user?.name)}
+              </h1>
+              <p className="mt-1.5 text-slate-500 text-sm">
+                {data.todayItems > 0
+                  ? `You have ${data.todayItems} item${data.todayItems > 1 ? "s" : ""} scheduled for today.`
+                  : "Your editorial workspace is ready."}
+              </p>
             </div>
-            <h1 className="text-4xl md:text-5xl text-white max-w-3xl leading-tight" style={{ fontFamily: "var(--font-display)" }}>
-              {greeting(user?.name)}
-            </h1>
-            <p className="mt-3 text-slate-300 text-base md:text-lg max-w-2xl leading-relaxed">
-              {stats.todayItems > 0
-                ? `You have ${stats.todayItems} item${stats.todayItems > 1 ? "s" : ""} scheduled for today.`
-                : "Your editorial workspace is ready. Pick a tool or check the calendar to get started."}
-            </p>
-            <div className="mt-6 flex flex-wrap gap-3">
-              <Link href="/calendar" className="rounded-2xl bg-accent text-white px-5 py-3 text-sm font-semibold hover:bg-accent-dim transition-colors">
-                Open Calendar
-              </Link>
-              <Link href="/history" className="rounded-2xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-900 hover:border-accent/30 hover:text-accent transition-colors">
-                Review History
-              </Link>
-            </div>
+            <Link
+              href="/tools"
+              className="inline-flex items-center gap-2 rounded-2xl bg-accent px-5 py-2.5 text-sm font-semibold text-white hover:bg-accent-dim transition-colors shrink-0"
+            >
+              <PenLine className="h-4 w-4" />
+              Start creating
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
           </div>
 
-          <div className="grid sm:grid-cols-2 xl:grid-cols-2 gap-3">
-            {[
-              { label: "Saves this week", value: stats.recentSaves, meta: "history entries" },
-              { label: "Today's items", value: stats.todayItems, meta: "on the calendar" },
-              { label: "Failed publishes", value: stats.failedPublishes, meta: stats.failedPublishes > 0 ? "need retry" : "all clear" },
-              { label: "Tool library", value: TOOLS.length, meta: "available tools" },
-            ].map((stat) => (
-              <div key={stat.label} className="shell-stat-card rounded-3xl p-5">
-                <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">{stat.label}</p>
-                <div className="mt-3 flex items-end justify-between gap-3">
-                  <div className="text-3xl font-semibold text-white" style={{ fontFamily: "var(--font-display)" }}>
-                    {stat.value}
-                  </div>
-                  <span className={`text-xs ${stat.label === "Failed publishes" && stat.value > 0 ? "text-red-400" : "text-accent"}`}>
-                    {stat.meta}
+          {/* Stats row */}
+          <div className="mt-6 grid grid-cols-2 lg:grid-cols-4 gap-3">
+            {stats.map((s) => (
+              <div key={s.label} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-slate-400">{s.label}</p>
+                <div className="mt-2 flex items-end justify-between gap-2">
+                  <span className="text-2xl font-semibold text-slate-900" style={{ fontFamily: "var(--font-display)" }}>
+                    {s.value}
                   </span>
+                  <span className={`text-xs pb-0.5 ${s.warn ? "text-red-500" : "text-accent"}`}>{s.sub}</span>
                 </div>
               </div>
             ))}
           </div>
         </div>
-      </section>
+      </div>
 
-      {/* Attention strip */}
-      {hasAttention && (
-        <section className="flex flex-wrap gap-3">
-          {isAdmin && stats.pendingUsers > 0 && (
-            <Link href="/admin/users" className="flex-1 min-w-[200px] shell-panel rounded-2xl px-5 py-4 border border-amber-400/30 bg-amber-400/5 hover:border-amber-400/50 transition-colors group">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-[11px] font-mono uppercase tracking-wider text-amber-600 mb-1">Access Requests</p>
-                  <p className="text-sm font-semibold text-slate-900">
-                    {stats.pendingUsers} user{stats.pendingUsers > 1 ? "s" : ""} awaiting approval
-                  </p>
-                </div>
-                <span className="text-amber-500 group-hover:translate-x-0.5 transition-transform text-lg">→</span>
-              </div>
-            </Link>
-          )}
-          {stats.failedPublishes > 0 && (
-            <Link href="/history?publish_state=failed" className="flex-1 min-w-[200px] shell-panel rounded-2xl px-5 py-4 border border-red-400/30 bg-red-400/5 hover:border-red-400/50 transition-colors group">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-[11px] font-mono uppercase tracking-wider text-red-600 mb-1">Publish Failures</p>
-                  <p className="text-sm font-semibold text-slate-900">
-                    {stats.failedPublishes} draft{stats.failedPublishes > 1 ? "s" : ""} failed to publish
-                  </p>
-                </div>
-                <span className="text-red-500 group-hover:translate-x-0.5 transition-transform text-lg">→</span>
-              </div>
-            </Link>
-          )}
-        </section>
-      )}
+      <div className="px-8 py-8 max-w-5xl mx-auto space-y-6">
 
-      {/* Quick actions + recent activity */}
-      <section className="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
-        <div className="grid gap-3">
-          {QUICK_ACTIONS.map((action) => (
-            <Link key={action.href} href={action.href} className="group shell-panel rounded-[1.75rem] p-5 shell-hover-lift transition-colors">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">{action.label}</p>
-                  <h3 className="text-xl text-white mt-2 group-hover:text-accent transition-colors" style={{ fontFamily: "var(--font-display)" }}>
-                    {action.title}
-                  </h3>
-                  <p className="text-sm text-slate-400 mt-2 leading-relaxed">{action.description}</p>
+        {/* Attention alerts */}
+        {hasAttention && (
+          <div className="flex flex-wrap gap-3">
+            {isAdmin && data.pendingUsers > 0 && (
+              <Link
+                href="/admin/users"
+                className="flex-1 min-w-[200px] flex items-center justify-between gap-4 rounded-2xl border border-amber-300 bg-amber-50 px-5 py-3.5 hover:border-amber-400 transition-colors group"
+              >
+                <div className="flex items-center gap-3">
+                  <Users className="h-4 w-4 text-amber-600 shrink-0" />
+                  <div>
+                    <p className="text-[11px] font-mono uppercase tracking-wider text-amber-600">Access Requests</p>
+                    <p className="text-sm font-medium text-slate-800 mt-0.5">
+                      {data.pendingUsers} user{data.pendingUsers > 1 ? "s" : ""} awaiting approval
+                    </p>
+                  </div>
                 </div>
-                <span className="text-3xl shrink-0">{action.icon}</span>
-              </div>
-            </Link>
-          ))}
-        </div>
+                <ArrowRight className="h-4 w-4 text-amber-500 group-hover:translate-x-0.5 transition-transform shrink-0" />
+              </Link>
+            )}
+            {data.failedPublishes > 0 && (
+              <Link
+                href="/history?publish_state=failed"
+                className="flex-1 min-w-[200px] flex items-center justify-between gap-4 rounded-2xl border border-red-300 bg-red-50 px-5 py-3.5 hover:border-red-400 transition-colors group"
+              >
+                <div className="flex items-center gap-3">
+                  <AlertTriangle className="h-4 w-4 text-red-600 shrink-0" />
+                  <div>
+                    <p className="text-[11px] font-mono uppercase tracking-wider text-red-600">Publish Failures</p>
+                    <p className="text-sm font-medium text-slate-800 mt-0.5">
+                      {data.failedPublishes} draft{data.failedPublishes > 1 ? "s" : ""} failed to publish
+                    </p>
+                  </div>
+                </div>
+                <ArrowRight className="h-4 w-4 text-red-500 group-hover:translate-x-0.5 transition-transform shrink-0" />
+              </Link>
+            )}
+          </div>
+        )}
 
-        <div className="space-y-4">
-          {/* Recent history */}
-          <div className="shell-panel rounded-[2rem] p-6">
-            <p className="font-mono text-[11px] text-accent uppercase tracking-[0.24em] mb-4">Recent Saves</p>
-            {stats.recentHistory.length === 0 ? (
-              <p className="text-sm text-slate-400">No saved content yet. Generate something and save it to history.</p>
+        {/* Recent work + Upcoming */}
+        <div className="grid gap-4 lg:grid-cols-2">
+
+          {/* Recent saves */}
+          <div className="rounded-2xl border border-slate-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <History className="h-4 w-4 text-slate-400" />
+                <p className="text-sm font-semibold text-slate-700">Recent work</p>
+              </div>
+              <Link href="/history" className="text-xs text-accent hover:underline">View all</Link>
+            </div>
+            {data.recentHistory.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-sm text-slate-400">No saved content yet.</p>
+                <Link href="/tools" className="mt-2 inline-block text-xs text-accent hover:underline">
+                  Use a tool to generate your first piece →
+                </Link>
+              </div>
             ) : (
-              <div className="space-y-2">
-                {stats.recentHistory.map((entry) => (
-                  <Link key={entry.id} href={`/history`} className="flex items-center gap-3 rounded-2xl p-3 hover:bg-black/5 transition-colors group">
-                    <span className="text-xl shrink-0">{entry.tool_icon}</span>
+              <div className="space-y-1">
+                {data.recentHistory.map((entry) => (
+                  <Link
+                    key={entry.id}
+                    href="/history"
+                    className="flex items-center gap-3 rounded-xl px-3 py-2.5 hover:bg-slate-50 transition-colors group"
+                  >
+                    <span className="text-base shrink-0">{entry.tool_icon}</span>
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-slate-900 truncate group-hover:text-accent transition-colors">{entry.title}</p>
-                      <p className="text-xs text-muted">{entry.tool_name} · {new Date(entry.created_at).toLocaleDateString()}</p>
+                      <p className="text-sm font-medium text-slate-800 truncate group-hover:text-accent transition-colors">
+                        {entry.title}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        {entry.tool_name} · {new Date(entry.created_at).toLocaleDateString()}
+                      </p>
                     </div>
                   </Link>
                 ))}
-                <Link href="/history" className="block text-xs text-center text-accent hover:text-accent-dim pt-1 transition-colors">View all →</Link>
               </div>
             )}
           </div>
 
           {/* Upcoming calendar */}
-          <div className="shell-panel rounded-[2rem] p-6">
-            <p className="font-mono text-[11px] text-accent uppercase tracking-[0.24em] mb-4">Upcoming</p>
-            {stats.upcomingItems.length === 0 ? (
-              <p className="text-sm text-slate-400">Nothing scheduled. Add items to the calendar to see them here.</p>
+          <div className="rounded-2xl border border-slate-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-slate-400" />
+                <p className="text-sm font-semibold text-slate-700">Up next</p>
+              </div>
+              <Link href="/calendar" className="text-xs text-accent hover:underline">Open calendar</Link>
+            </div>
+            {data.upcomingItems.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-sm text-slate-400">Nothing scheduled.</p>
+                <Link href="/calendar" className="mt-2 inline-block text-xs text-accent hover:underline">
+                  Plan content on the calendar →
+                </Link>
+              </div>
             ) : (
-              <div className="space-y-2">
-                {stats.upcomingItems.map((item) => (
-                  <Link key={item.id} href="/calendar" className="flex items-center gap-3 rounded-2xl p-3 hover:bg-black/5 transition-colors group">
-                    <div className="h-10 w-10 rounded-xl bg-accent/10 border border-accent/20 flex flex-col items-center justify-center shrink-0">
-                      <span className="text-[10px] font-mono text-accent leading-none">
-                        {new Date(`${item.scheduled_for}T00:00:00`).toLocaleDateString(undefined, { month: "short" }).toUpperCase()}
-                      </span>
-                      <span className="text-sm font-bold text-accent leading-none">
-                        {new Date(`${item.scheduled_for}T00:00:00`).getDate()}
-                      </span>
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-slate-900 truncate group-hover:text-accent transition-colors">{item.title}</p>
-                      <p className="text-xs text-muted capitalize">{item.status}</p>
-                    </div>
-                  </Link>
-                ))}
-                <Link href="/calendar" className="block text-xs text-center text-accent hover:text-accent-dim pt-1 transition-colors">Open calendar →</Link>
+              <div className="space-y-1">
+                {data.upcomingItems.map((item) => {
+                  const d = new Date(`${item.scheduled_for}T00:00:00`);
+                  return (
+                    <Link
+                      key={item.id}
+                      href="/calendar"
+                      className="flex items-center gap-3 rounded-xl px-3 py-2.5 hover:bg-slate-50 transition-colors group"
+                    >
+                      <div className="h-10 w-10 rounded-xl bg-accent/10 flex flex-col items-center justify-center shrink-0">
+                        <span className="text-[9px] font-mono text-accent uppercase leading-none">
+                          {d.toLocaleDateString(undefined, { month: "short" })}
+                        </span>
+                        <span className="text-sm font-bold text-accent leading-none">{d.getDate()}</span>
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-slate-800 truncate group-hover:text-accent transition-colors">
+                          {item.title}
+                        </p>
+                        <p className="text-xs text-slate-400 capitalize">{item.status.replace(/-/g, " ")}</p>
+                      </div>
+                    </Link>
+                  );
+                })}
               </div>
             )}
           </div>
         </div>
-      </section>
 
-      <section className="grid gap-4 xl:grid-cols-2">
+        {/* SEO trend */}
         <SeoScoreTrendCard />
-        <div className="shell-panel rounded-[2rem] p-6 md:p-7">
-          <p className="font-mono text-[11px] text-accent uppercase tracking-[0.24em] mb-3">Guided Workflow Presets</p>
-          <h2 className="text-2xl md:text-3xl text-white" style={{ fontFamily: "var(--font-display)" }}>
-            Launch repeatable pipelines without rebuilding prompts from scratch.
-          </h2>
-          <div className="mt-5 space-y-3">
-            {WORKFLOW_PRESETS.map((preset) => (
-              <Link key={preset.id} href={getSeoWorkspacePresetHref(preset.id)} className="group block shell-panel-soft rounded-3xl p-4 border border-transparent hover:border-accent/30 transition-colors">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">{preset.stage}</p>
-                    <h3 className="text-lg text-white mt-1 group-hover:text-accent transition-colors" style={{ fontFamily: "var(--font-display)" }}>
-                      {preset.name}
-                    </h3>
-                    <p className="text-sm text-slate-400 mt-2 leading-relaxed">{preset.description}</p>
-                  </div>
-                  <span className="text-xs font-mono text-accent mt-1">Launch</span>
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {preset.steps.slice(0, 3).map((step) => (
-                    <span key={step} className="text-[11px] font-mono rounded-full border border-border px-2 py-1 text-slate-500">{step}</span>
-                  ))}
-                </div>
-              </Link>
-            ))}
-          </div>
-        </div>
 
-        <div className="shell-panel rounded-[2rem] p-6 md:p-7">
-          <p className="font-mono text-[11px] text-accent uppercase tracking-[0.24em] mb-3">Starter Templates</p>
-          <h2 className="text-2xl md:text-3xl text-white" style={{ fontFamily: "var(--font-display)" }}>
-            Onboard teams with pre-structured first-week operating patterns.
-          </h2>
-          <div className="mt-5 grid gap-3">
-            {STARTER_TEMPLATES.map((template) => (
-              <Link key={template.id} href={template.href} className="group shell-panel-soft rounded-3xl p-4 border border-transparent hover:border-accent/30 transition-colors">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-mono uppercase tracking-[0.2em] text-slate-500">{template.persona}</p>
-                  <span className="text-xs font-mono text-slate-500">Template</span>
-                </div>
-                <h3 className="text-xl text-white mt-2 group-hover:text-accent transition-colors" style={{ fontFamily: "var(--font-display)" }}>
-                  {template.title}
-                </h3>
-                <p className="text-sm text-slate-400 mt-2 leading-relaxed">{template.description}</p>
-              </Link>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {categories.map((cat) => {
-        const tools = TOOLS.filter((t) => t.category === cat);
-        return (
-          <section key={cat} className="shell-panel rounded-[2rem] p-5 md:p-6">
-            <div className="flex flex-wrap items-center gap-3 mb-5">
-              <span className="text-2xl">{CATEGORY_ICONS[cat] || "🔧"}</span>
-              <h2 className="text-xl text-white" style={{ fontFamily: "var(--font-display)" }}>{cat}</h2>
-              <span className="font-mono text-xs text-slate-400 shell-badge px-2.5 py-1 rounded-full">{tools.length} tools</span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-              {tools.map((tool) => (
-                <Link key={tool.slug} href={`/tool/${tool.slug}`} className="group shell-panel-soft rounded-[1.5rem] p-4 md:p-5 transition-colors hover:border-accent/30">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <div className="text-2xl mb-3">{tool.icon}</div>
-                      <div className="text-base font-medium text-white group-hover:text-accent transition-colors mb-2">{tool.name}</div>
-                    </div>
-                    <span className="text-[11px] font-mono uppercase tracking-[0.18em] text-slate-500">Tool</span>
-                  </div>
-                  <div className="text-sm text-slate-400 line-clamp-2 leading-relaxed">{tool.description}</div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        );
-      })}
+      </div>
     </div>
   );
 }

--- a/app/seo/page.tsx
+++ b/app/seo/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { TrendingUp } from "lucide-react";
 import { PageHeader, StatusStrip } from "@/components/DashboardPrimitives";
 import type { HistoryRow } from "@/lib/db";
 import { WORKFLOW_PRESETS } from "@/lib/workflow-presets";
@@ -99,6 +100,7 @@ function SeoWorkspacePageContent() {
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [copyLabel, setCopyLabel] = useState("Copy Report");
   const [metaDescription, setMetaDescription] = useState("");
+  const [leftTab, setLeftTab] = useState<"analysis" | "workflow" | "collaboration">("analysis");
 
   useEffect(() => {
     if (!saveMessage) return;
@@ -340,181 +342,237 @@ function SeoWorkspacePageContent() {
       />
 
       <section className="grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
-        <div className="shell-panel rounded-[2rem] p-5 space-y-4">
-          <div>
-            <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Draft Source</p>
-            <select
-              className="w-full input-base"
-              value={selectedId ?? ""}
-              onChange={(event) => setSelectedId(event.target.value ? Number(event.target.value) : null)}
-              disabled={loadingRows}
-            >
-              <option value="">Select a saved history draft...</option>
-              {rows.map((row) => (
-                <option key={row.id} value={row.id}>
-                  {row.tool_icon} {row.title}
-                </option>
-              ))}
-            </select>
+        <div className="shell-panel rounded-[2rem] overflow-hidden flex flex-col">
+          {/* Tab bar */}
+          <div className="flex border-b border-white/10 px-2 pt-2">
+            {(["analysis", "workflow", "collaboration"] as const).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setLeftTab(tab)}
+                className={`px-4 py-2.5 text-xs font-mono uppercase tracking-[0.18em] rounded-t-xl transition-colors ${
+                  leftTab === tab
+                    ? "bg-white/[0.06] text-white border-b-2 border-accent"
+                    : "text-slate-500 hover:text-slate-300"
+                }`}
+              >
+                {tab === "analysis" ? "Analysis" : tab === "workflow" ? "Workflow" : "Collaboration"}
+              </button>
+            ))}
           </div>
 
-          <div>
-            <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Focus Keyword</p>
-            <input
-              className="w-full input-base"
-              value={focusKeyword}
-              onChange={(event) => setFocusKeyword(event.target.value)}
-              placeholder="e.g. developer content workflow"
-              disabled={!selectedRow}
-            />
-            {focusKeyword && (
-              <p className="text-[11px] text-slate-500 mt-1">{focusKeyword.length} characters · {focusKeyword.trim().split(/\s+/).filter((w) => w.length > 0).length} word(s)</p>
+          <div className="p-5 space-y-4 flex-1 overflow-y-auto">
+            {/* Analysis tab */}
+            {leftTab === "analysis" && (
+              <>
+                <div>
+                  <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Draft Source</p>
+                  <select
+                    className="w-full input-base"
+                    value={selectedId ?? ""}
+                    onChange={(event) => setSelectedId(event.target.value ? Number(event.target.value) : null)}
+                    disabled={loadingRows}
+                  >
+                    <option value="">Select a saved history draft...</option>
+                    {rows.map((row) => (
+                      <option key={row.id} value={row.id}>
+                        {row.tool_icon} {row.title}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Focus Keyword</p>
+                  <input
+                    className="w-full input-base"
+                    value={focusKeyword}
+                    onChange={(event) => setFocusKeyword(event.target.value)}
+                    placeholder="e.g. developer content workflow"
+                    disabled={!selectedRow}
+                  />
+                  {focusKeyword && (
+                    <p className="text-[11px] text-slate-500 mt-1">
+                      {focusKeyword.length} chars · {focusKeyword.trim().split(/\s+/).filter((w) => w.length > 0).length} word(s)
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <button onClick={handleAnalyze} disabled={!selectedRow || analyzing} className="btn-primary">
+                    {analyzing ? "Analyzing..." : "Run SEO Analysis"}
+                  </button>
+                  <button onClick={handleSave} disabled={!selectedRow || saving} className="btn-secondary">
+                    {saving ? "Saving..." : "Save Metadata"}
+                  </button>
+                </div>
+                {saveMessage && <p className="text-sm text-slate-600">{saveMessage}</p>}
+              </>
+            )}
+
+            {/* Workflow tab */}
+            {leftTab === "workflow" && (
+              <>
+                <div>
+                  <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Workflow Preset</p>
+                  <select
+                    className="w-full input-base"
+                    value={presetId}
+                    onChange={(event) => setPresetId(event.target.value)}
+                    disabled={!selectedRow}
+                  >
+                    <option value="">None</option>
+                    {WORKFLOW_PRESETS.map((preset) => (
+                      <option key={preset.id} value={preset.id}>{preset.name}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Workflow Stage</p>
+                  <div className="flex flex-wrap gap-2">
+                    {WORKFLOW_STAGES.map((stage, i) => {
+                      const currentIndex = WORKFLOW_STAGES.indexOf(workflowStage);
+                      const done = i < currentIndex;
+                      const active = i === currentIndex;
+                      return (
+                        <button
+                          key={stage}
+                          onClick={() => selectedRow && setWorkflowStage(stage)}
+                          disabled={!selectedRow}
+                          className={`px-3 py-1.5 rounded-xl text-xs font-medium border transition-all disabled:opacity-40 ${
+                            active
+                              ? "bg-accent text-white border-accent/30"
+                              : done
+                              ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
+                              : "bg-white/[0.03] text-slate-500 border-white/10 hover:text-slate-300"
+                          }`}
+                        >
+                          {done ? "✓ " : ""}{stage}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {presetId && (() => {
+                  const preset = WORKFLOW_PRESETS.find((p) => p.id === presetId);
+                  if (!preset) return null;
+                  const currentStageIndex = WORKFLOW_STAGES.indexOf(workflowStage);
+                  return (
+                    <div className="shell-panel-soft rounded-2xl p-4 space-y-2">
+                      <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">{preset.name} — Steps</p>
+                      <ol className="space-y-1.5 mt-1">
+                        {preset.steps.map((step, index) => {
+                          const stepStageIndex = preset.steps.length > 1
+                            ? Math.round((index / (preset.steps.length - 1)) * (WORKFLOW_STAGES.length - 1))
+                            : 0;
+                          const done = currentStageIndex > stepStageIndex;
+                          const active = currentStageIndex === stepStageIndex;
+                          return (
+                            <li key={step} className={`flex items-center gap-2 text-xs ${done ? "text-emerald-400" : active ? "text-white" : "text-slate-500"}`}>
+                              <span className={`h-4 w-4 rounded-full border flex items-center justify-center shrink-0 text-[9px] ${done ? "border-emerald-500 bg-emerald-500/20" : active ? "border-accent bg-accent/20" : "border-white/20"}`}>
+                                {done ? "✓" : active ? "▶" : ""}
+                              </span>
+                              {step}
+                            </li>
+                          );
+                        })}
+                      </ol>
+                    </div>
+                  );
+                })()}
+
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <button onClick={handleSave} disabled={!selectedRow || saving} className="btn-secondary">
+                    {saving ? "Saving..." : "Save Stage"}
+                  </button>
+                </div>
+                {saveMessage && <p className="text-sm text-slate-600">{saveMessage}</p>}
+              </>
+            )}
+
+            {/* Collaboration tab */}
+            {leftTab === "collaboration" && (
+              <>
+                <div className="grid grid-cols-1 gap-3">
+                  <div>
+                    <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Review Status</label>
+                    <select
+                      className="w-full input-base"
+                      value={collaborationStatus}
+                      onChange={(event) => setCollaborationStatus(event.target.value)}
+                      disabled={!selectedRow}
+                    >
+                      {COLLABORATION_STATUSES.map((status) => (
+                        <option key={status} value={status}>{status}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-1.5">Assignee</label>
+                    <input
+                      className="w-full input-base"
+                      value={assignee}
+                      onChange={(event) => setAssignee(event.target.value)}
+                      placeholder="Owner or reviewer name"
+                      disabled={!selectedRow}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-mono text-slate-500 uppercase tracking-wider mb-2">Add Note</label>
+                  <div className="flex gap-2">
+                    <input
+                      className="input-base w-28 shrink-0"
+                      value={commentAuthor}
+                      onChange={(event) => setCommentAuthor(event.target.value)}
+                      placeholder="Author"
+                      disabled={!selectedRow}
+                    />
+                    <input
+                      className="input-base flex-1"
+                      value={commentDraft}
+                      onChange={(event) => setCommentDraft(event.target.value)}
+                      placeholder="Note"
+                      disabled={!selectedRow}
+                    />
+                    <button onClick={handleAddComment} className="btn-secondary shrink-0" disabled={!selectedRow}>
+                      Add
+                    </button>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  {comments.length === 0 && (
+                    <p className="text-xs text-slate-500 py-4 text-center">No notes yet.</p>
+                  )}
+                  {comments.map((comment) => (
+                    <div key={comment.id} className="rounded-2xl border border-border bg-white/[0.03] px-3 py-2.5">
+                      <div className="flex items-center justify-between gap-2 mb-1">
+                        <span className="text-xs font-semibold text-slate-800">{comment.author}</span>
+                        <span className="text-[11px] text-slate-500">{formatDate(comment.created_at)}</span>
+                      </div>
+                      <p className="text-sm text-slate-700">{comment.message}</p>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <button onClick={handleSave} disabled={!selectedRow || saving} className="btn-secondary">
+                    {saving ? "Saving..." : "Save"}
+                  </button>
+                </div>
+                {saveMessage && <p className="text-sm text-slate-600">{saveMessage}</p>}
+              </>
             )}
           </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Workflow Preset</p>
-              <select
-                className="w-full input-base"
-                value={presetId}
-                onChange={(event) => setPresetId(event.target.value)}
-                disabled={!selectedRow}
-              >
-                <option value="">None</option>
-                {WORKFLOW_PRESETS.map((preset) => (
-                  <option key={preset.id} value={preset.id}>
-                    {preset.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500 mb-2">Workflow Stage</p>
-              <select
-                className="w-full input-base"
-                value={workflowStage}
-                onChange={(event) => setWorkflowStage(event.target.value)}
-                disabled={!selectedRow}
-              >
-                {WORKFLOW_STAGES.map((stage) => (
-                  <option key={stage} value={stage}>
-                    {stage}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          {presetId && (() => {
-            const preset = WORKFLOW_PRESETS.find((p) => p.id === presetId);
-            if (!preset) return null;
-            const currentStageIndex = WORKFLOW_STAGES.indexOf(workflowStage);
-            return (
-              <div className="shell-panel-soft rounded-3xl p-4 space-y-2">
-                <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">{preset.name} · Steps</p>
-                <ol className="space-y-1 mt-1">
-                  {preset.steps.map((step, index) => {
-                    const stepStageIndex = preset.steps.length > 1
-                      ? Math.round((index / (preset.steps.length - 1)) * (WORKFLOW_STAGES.length - 1))
-                      : 0;
-                    const done = currentStageIndex > stepStageIndex;
-                    const active = currentStageIndex === stepStageIndex;
-                    return (
-                      <li key={step} className={`flex items-center gap-2 text-xs ${done ? "text-emerald-500" : active ? "text-white" : "text-slate-500"}`}>
-                        <span className="shrink-0">{done ? "✓" : active ? "▶" : "○"}</span>
-                        {step}
-                      </li>
-                    );
-                  })}
-                </ol>
-              </div>
-            );
-          })()}
-
-          <div className="shell-panel-soft rounded-3xl p-4 space-y-3">
-            <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">Collaboration</p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs text-slate-500 mb-1">Review Status</label>
-                <select
-                  className="w-full input-base"
-                  value={collaborationStatus}
-                  onChange={(event) => setCollaborationStatus(event.target.value)}
-                  disabled={!selectedRow}
-                >
-                  {COLLABORATION_STATUSES.map((status) => (
-                    <option key={status} value={status}>
-                      {status}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="block text-xs text-slate-500 mb-1">Assignee</label>
-                <input
-                  className="w-full input-base"
-                  value={assignee}
-                  onChange={(event) => setAssignee(event.target.value)}
-                  placeholder="Owner or reviewer name"
-                  disabled={!selectedRow}
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-[0.3fr_0.7fr_auto] gap-2">
-              <input
-                className="input-base"
-                value={commentAuthor}
-                onChange={(event) => setCommentAuthor(event.target.value)}
-                placeholder="Author"
-                disabled={!selectedRow}
-              />
-              <input
-                className="input-base"
-                value={commentDraft}
-                onChange={(event) => setCommentDraft(event.target.value)}
-                placeholder="Add collaboration note"
-                disabled={!selectedRow}
-              />
-              <button
-                onClick={handleAddComment}
-                className="btn-secondary"
-                disabled={!selectedRow}
-              >
-                Add
-              </button>
-            </div>
-
-            <div className="space-y-2 max-h-40 overflow-y-auto">
-              {comments.length === 0 && <p className="text-xs text-slate-500">No comments yet.</p>}
-              {comments.map((comment) => (
-                <div key={comment.id} className="rounded-2xl border border-border bg-white/[0.04] px-3 py-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-xs font-medium text-slate-900">{comment.author}</span>
-                    <span className="text-[11px] text-slate-500">{formatDate(comment.created_at)}</span>
-                  </div>
-                  <p className="text-sm text-slate-700 mt-1">{comment.message}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <button onClick={handleAnalyze} disabled={!selectedRow || analyzing} className="btn-primary">
-              {analyzing ? "Analyzing..." : "Run SEO Analysis"}
-            </button>
-            <button onClick={handleSave} disabled={!selectedRow || saving} className="btn-secondary">
-              {saving ? "Saving..." : "Save Metadata"}
-            </button>
-          </div>
-          {saveMessage && <p className="text-sm text-slate-600">{saveMessage}</p>}
         </div>
 
         <div className="shell-panel rounded-[2rem] p-5">
           {!selectedRow ? (
             <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-              <span className="text-4xl opacity-30">📈</span>
+              <TrendingUp className="w-10 h-10 opacity-30 text-slate-400" />
               <p className="text-[11px] font-mono uppercase tracking-[0.22em] text-slate-500">No Draft Selected</p>
               <p className="text-sm text-slate-400 max-w-xs">Pick a saved history draft from the left panel to load its SEO score, checklist, and optimization guidance.</p>
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,15 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Cpu } from "lucide-react";
 import { PageHeader, SectionCard, SurfaceNotice } from "@/components/DashboardPrimitives";
+
+const MODEL_OPTIONS = [
+  { id: "claude-haiku-4-5-20251001", label: "Haiku 4.5", description: "Fast & economical. Best for short-form content and quick drafts." },
+  { id: "claude-sonnet-4-6", label: "Sonnet 4.6", description: "Balanced performance. Recommended for most tools. (Default)" },
+  { id: "claude-opus-4-7", label: "Opus 4.7", description: "Most capable. Ideal for long-form, research-heavy, or complex content." },
+];
+const MODEL_STORAGE_KEY = "techscribe_model";
 
 interface WordPressSettingsResponse {
   site_url: string;
@@ -49,6 +57,15 @@ export default function SettingsPage() {
   const [error, setError] = useState<string | null>(null);
   const [testMessage, setTestMessage] = useState<string | null>(null);
   const [verifiedSignature, setVerifiedSignature] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState("claude-sonnet-4-6");
+  const [modelSaved, setModelSaved] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(MODEL_STORAGE_KEY);
+      if (saved && MODEL_OPTIONS.some((m) => m.id === saved)) setSelectedModel(saved);
+    } catch { /* ignore */ }
+  }, []);
 
   const currentPasswordToken = appPassword || (hasSavedPassword ? "__saved_password__" : "");
   const currentConfigSignature = getConfigSignature(siteUrl, username, currentPasswordToken);
@@ -173,15 +190,21 @@ export default function SettingsPage() {
     }
   };
 
+  const handleSaveModel = () => {
+    try { localStorage.setItem(MODEL_STORAGE_KEY, selectedModel); } catch { /* ignore */ }
+    setModelSaved(true);
+    setTimeout(() => setModelSaved(false), 2000);
+  };
+
   const inputClassName = "shell-input w-full rounded-2xl px-3.5 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none transition-colors";
 
   return (
     <div className="min-h-screen flex flex-col">
       <div className="p-5 md:p-8 max-w-6xl w-full mx-auto space-y-6">
         <PageHeader
-          eyebrow="Integrations"
-          title="WordPress Setup"
-          description="Save your publishing credentials, verify the connection, and keep draft publishing enabled without touching environment files."
+          eyebrow="Configuration"
+          title="Settings"
+          description="Manage your publishing credentials, generation model, and other workspace preferences."
           stats={[
             { label: "Source", value: loading ? "..." : source },
             { label: "Password", value: hasSavedPassword ? "Saved" : "Missing" },
@@ -190,7 +213,40 @@ export default function SettingsPage() {
           ]}
         />
 
+        <SectionCard className="space-y-5">
+          <div className="flex items-center gap-3">
+            <Cpu className="h-5 w-5 text-accent shrink-0" />
+            <div>
+              <p className="font-mono text-xs text-slate-500 uppercase tracking-wider mb-0.5">Generation Model</p>
+              <p className="text-sm text-slate-400">Choose which Claude model powers all content generation. Applies to every tool.</p>
+            </div>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {MODEL_OPTIONS.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => setSelectedModel(m.id)}
+                className={`text-left rounded-2xl border p-4 transition-colors ${
+                  selectedModel === m.id
+                    ? "border-accent bg-accent/10 text-white"
+                    : "border-white/10 text-slate-300 hover:border-white/20 hover:text-white"
+                }`}
+              >
+                <p className="font-medium text-sm">{m.label}</p>
+                <p className="text-xs text-slate-400 mt-1 leading-relaxed">{m.description}</p>
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleSaveModel}
+            className="inline-flex items-center gap-2 bg-accent text-white font-semibold px-5 py-3 rounded-2xl text-sm hover:bg-accent-dim transition-colors"
+          >
+            {modelSaved ? "Saved ✓" : "Save Model Preference"}
+          </button>
+        </SectionCard>
+
         <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <p className="col-span-full font-mono text-xs text-slate-500 uppercase tracking-wider">WordPress Integration</p>
           <SectionCard className="space-y-5">
             <div>
               <p className="font-mono text-xs text-slate-500 uppercase tracking-wider mb-1">Connection</p>

--- a/app/tool/[slug]/page.tsx
+++ b/app/tool/[slug]/page.tsx
@@ -8,7 +8,11 @@ import { getHandoffActions } from "@/lib/handoff-registry";
 import { parseToolOutput, ParsedToolOutput } from "@/lib/output-parsers";
 import HandoffCard from "@/components/HandoffCard";
 import AddKnowledgeModal, { ResearchItem } from "@/components/AddKnowledgeModal";
-import { EmptyState, PageHeader, StatusStrip } from "@/components/DashboardPrimitives";
+import { BookOpen, FileText, Link2, Pencil, SearchX, Sparkles } from "lucide-react";
+import { EmptyState, PageHeader } from "@/components/DashboardPrimitives";
+import { useToast } from "@/components/Toast";
+import { useKnowledgeBase } from "@/lib/use-knowledge-base";
+import { useMyTone, buildToneInstruction } from "@/lib/use-my-tone";
 import HelpDrawer from "@/components/HelpDrawer";
 import type { PublishState, PublishFailureCategory } from "@/lib/publish-state";
 import {
@@ -203,6 +207,53 @@ function FieldInput({
   );
 }
 
+function WorkflowStepper({
+  steps,
+  currentStep,
+  hint,
+}: {
+  steps: string[];
+  currentStep: number;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-center gap-4 px-6 py-3 border-b border-white/5 bg-white/[0.02]">
+      <div className="flex items-center">
+        {steps.map((step, i) => {
+          const done = i < currentStep;
+          const active = i === currentStep;
+          return (
+            <span key={step} className="flex items-center">
+              <span className={`flex items-center gap-1.5 text-xs font-medium px-1.5 py-1 rounded-lg transition-all ${
+                done ? "text-emerald-400" : active ? "text-white" : "text-slate-600"
+              }`}>
+                <span className={`h-5 w-5 rounded-full flex items-center justify-center text-[10px] font-bold border shrink-0 transition-all ${
+                  done
+                    ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-400"
+                    : active
+                      ? "bg-accent/15 border-accent/60 text-accent"
+                      : "bg-transparent border-white/15 text-slate-600"
+                }`}>
+                  {done ? "✓" : i + 1}
+                </span>
+                <span className={active ? "font-semibold" : ""}>{step}</span>
+              </span>
+              {i < steps.length - 1 && (
+                <span className={`w-8 h-px mx-1 block transition-all ${
+                  i < currentStep ? "bg-emerald-500/30" : "bg-white/10"
+                }`} />
+              )}
+            </span>
+          );
+        })}
+      </div>
+      {hint && (
+        <span className="text-xs text-slate-500 border-l border-white/10 pl-4 hidden sm:block">{hint}</span>
+      )}
+    </div>
+  );
+}
+
 function ToolPageContent() {
   const params = useParams();
   const searchParams = useSearchParams();
@@ -212,12 +263,14 @@ function ToolPageContent() {
   const calendarId = calendarIdParam ? Number.parseInt(calendarIdParam, 10) : null;
   const handoffActions = getHandoffActions(slug);
 
+  const { toast } = useToast();
+  const { entries: knowledgeEntries } = useKnowledgeBase();
+  const { config: toneConfig } = useMyTone();
+
   const [fields, setFields] = useState<Record<string, string>>({});
   const [output, setOutput] = useState("");
   const [parsedOutput, setParsedOutput] = useState<ParsedToolOutput | null>(null);
   const [loading, setLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [saved, setSaved] = useState(false);
   const [historyId, setHistoryId] = useState<number | null>(null);
   const [draftPostId, setDraftPostId] = useState<number | null>(null);
   const [publishing, setPublishing] = useState(false);
@@ -250,7 +303,6 @@ function ToolPageContent() {
       : output
         ? "Output ready"
         : "Ready";
-  const saveStateLabel = historyId ? `Saved #${historyId}` : saved ? "Saved" : "Not saved";
   const publishStateLabel = draftPostId
     ? publishedDraftUrl
       ? "Draft linked"
@@ -272,6 +324,7 @@ function ToolPageContent() {
 
   // Photos option state — rendered for all tools but only displayed when tool.supportsPhotos is true
   const [includePhotos, setIncludePhotos] = useState(false);
+  const [includeKnowledge, setIncludeKnowledge] = useState(false);
 
   // Output tab state (ARTICLE = rendered, EDITOR = editable textarea)
   type OutputTab = "article" | "editor";
@@ -296,7 +349,7 @@ function ToolPageContent() {
     setOutput("");
     setParsedOutput(null);
     setError("");
-    setSaved(false);
+
     setHistoryId(null);
     setDraftPostId(null);
     setPublishedDraftUrl(null);
@@ -332,11 +385,46 @@ function ToolPageContent() {
     void loadPublishStatus();
   }, []);
 
+  const generateFnRef = useRef<() => void>(() => {});
+  const [draftOutput, setDraftOutput] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        generateFnRef.current?.();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    setDraftOutput(null);
+    try {
+      const raw = localStorage.getItem(`techscribe_draft_${slug}`);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as { output: string; timestamp: number };
+      if (Date.now() - saved.timestamp < 48 * 60 * 60 * 1000 && saved.output) {
+        setDraftOutput(saved.output);
+      }
+    } catch { /* ignore */ }
+  }, [slug]);
+
+  useEffect(() => {
+    if (!output || !slug) return;
+    const timer = setTimeout(() => {
+      try {
+        localStorage.setItem(`techscribe_draft_${slug}`, JSON.stringify({ output, timestamp: Date.now() }));
+      } catch { /* ignore */ }
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [output, slug]);
+
   if (!tool) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
-          <div className="text-4xl mb-4">🔍</div>
+          <SearchX className="w-10 h-10 mx-auto mb-4 text-slate-500 opacity-50" />
           <div className="text-white text-lg mb-2">Tool not found</div>
           <Link href="/" className="text-accent text-sm hover:underline">
             ← Back to Dashboard
@@ -361,7 +449,7 @@ function ToolPageContent() {
     setOutput("");
     setParsedOutput(null);
     setError("");
-    setSaved(false);
+
     setHistoryId(null);
     setDraftPostId(null);
     setPublishedDraftUrl(null);
@@ -376,7 +464,18 @@ function ToolPageContent() {
       const res = await fetch("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug: tool.slug, fields, mode, research: researchItems, includePhotos: isOutlineMode ? false : includePhotos }),
+        body: JSON.stringify({
+          slug: tool.slug,
+          fields,
+          mode,
+          research: [
+            ...researchItems,
+            ...(includeKnowledge ? knowledgeEntries.map((e) => ({ id: e.id, type: e.type === "url" ? "url" : "text" as const, label: e.title, content: e.content })) : []),
+          ],
+          includePhotos: isOutlineMode ? false : includePhotos,
+          toneInstruction: buildToneInstruction(toneConfig),
+          model: localStorage.getItem("techscribe_model") ?? "claude-sonnet-4-6",
+        }),
       });
 
       if (!res.ok) {
@@ -416,7 +515,7 @@ function ToolPageContent() {
     setLoading(true);
     setOutput("");
     setError("");
-    setSaved(false);
+
     setHistoryId(null);
     setDraftPostId(null);
     setPublishedDraftUrl(null);
@@ -429,7 +528,19 @@ function ToolPageContent() {
       const res = await fetch("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug: tool.slug, fields, mode: "article", outline: editableOutline, research: researchItems, includePhotos }),
+        body: JSON.stringify({
+          slug: tool.slug,
+          fields,
+          mode: "article",
+          outline: editableOutline,
+          research: [
+            ...researchItems,
+            ...(includeKnowledge ? knowledgeEntries.map((e) => ({ id: e.id, type: e.type === "url" ? "url" : "text" as const, label: e.title, content: e.content })) : []),
+          ],
+          includePhotos,
+          toneInstruction: buildToneInstruction(toneConfig),
+          model: localStorage.getItem("techscribe_model") ?? "claude-sonnet-4-6",
+        }),
       });
 
       if (!res.ok) {
@@ -460,8 +571,7 @@ function ToolPageContent() {
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(output);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    toast("Copied to clipboard");
   };
 
   const handleSave = async (): Promise<number | null> => {
@@ -479,13 +589,19 @@ function ToolPageContent() {
       });
       if (res.ok) {
         const entry = await res.json();
-        setSaved(true);
         setHistoryId(entry.id);
-        setTimeout(() => setSaved(false), 3000);
+        toast("Saved to history");
+        try { localStorage.removeItem(`techscribe_draft_${slug}`); } catch { /* ignore */ }
+        setDraftOutput(null);
+        if (entry.cannibalizationWarning?.length) {
+          const titles = entry.cannibalizationWarning.map((e: { title: string }) => `"${e.title}"`).join(", ");
+          toast(`Keyword overlap detected with ${titles}`, "info");
+        }
         return entry.id as number;
       }
+      toast("Save failed — please try again", "error");
     } catch {
-      // silently ignore
+      toast("Save failed — please try again", "error");
     }
 
     return null;
@@ -539,6 +655,7 @@ function ToolPageContent() {
       if (currentHistoryId) {
         setHistoryId(currentHistoryId);
       }
+      toast("Published to WordPress", "success");
     } catch (err) {
       setError(err instanceof Error ? err.message : "WordPress publish failed");
     } finally {
@@ -550,7 +667,7 @@ function ToolPageContent() {
     setOutput("");
     setParsedOutput(null);
     setError("");
-    setSaved(false);
+
     setHistoryId(null);
     setDraftPostId(null);
     setPublishedDraftUrl(null);
@@ -574,30 +691,59 @@ function ToolPageContent() {
     setFields(defaults);
   };
 
+  generateFnRef.current = loading ? () => {} : articleStep === "outline-editing" ? handleGenerateArticle : handleGenerate;
+
   return (
     <div className="min-h-screen flex flex-col">
       <div className="p-5 md:p-8 max-w-[1600px] mx-auto w-full flex-1 flex flex-col gap-6">
         <PageHeader
-          eyebrow="Writing Workflow"
+          eyebrow={tool.category}
           title={tool.name}
           description={tool.description}
           icon={tool.icon}
           stats={[
-            { label: "Category", value: tool.category },
-            { label: "Workflow", value: isOutlineMode ? "Outline" : "Direct" },
+            { label: "Mode", value: isOutlineMode ? "Outline → Article" : "Direct generation" },
             { label: "Calendar", value: Number.isFinite(calendarId) ? "Linked" : "Standalone" },
             { label: "Publish", value: publishAllowed ? "Enabled" : "Restricted" },
           ]}
         />
 
-        <StatusStrip
-          items={[
-            { label: "Stage", value: workflowStageLabel },
-            { label: "Archive", value: saveStateLabel },
-            { label: "Draft Publish", value: publishStateLabel },
-            { label: "Output", value: output ? `${output.trim().split(/\s+/).filter(Boolean).length} words` : "Waiting for generation" },
-          ]}
-        />
+        {isOutlineMode ? (
+          <WorkflowStepper
+            steps={["Brief", "Outline", "Article", "Save"]}
+            currentStep={
+              articleStep === "input" ? 0
+              : articleStep === "outline-streaming" || articleStep === "outline-editing" ? 1
+              : articleStep === "article-streaming" ? 2
+              : historyId !== null ? 3
+              : 2
+            }
+            hint={
+              articleStep === "input" ? "Fill in the brief, then generate an outline"
+              : articleStep === "outline-streaming" ? "Generating your outline…"
+              : articleStep === "outline-editing" ? "Review and edit the outline, then generate the full article"
+              : articleStep === "article-streaming" ? "Writing your article…"
+              : articleStep === "article-done" && !historyId ? "Article ready — save or publish to finish"
+              : "Saved to history"
+            }
+          />
+        ) : (
+          <WorkflowStepper
+            steps={["Brief", "Generate", "Save"]}
+            currentStep={
+              !output && !loading ? 0
+              : loading ? 1
+              : historyId !== null ? 2
+              : 1
+            }
+            hint={
+              !output && !loading ? "Fill in the brief and click Generate"
+              : loading ? "Generating with Claude…"
+              : historyId !== null ? "Saved to history"
+              : "Output ready — save or copy to finish"
+            }
+          />
+        )}
 
         <div className="flex flex-1 overflow-hidden gap-6 min-h-0">
           <aside className="w-96 shell-panel rounded-[2rem] p-6 flex flex-col gap-4 overflow-y-auto shrink-0">
@@ -621,6 +767,29 @@ function ToolPageContent() {
               </div>
               )}
             </div>
+
+          {draftOutput && (
+            <div className="shell-panel-soft rounded-2xl px-4 py-3 flex items-center justify-between gap-3">
+              <p className="text-xs text-amber-300/90">Unsaved draft recovered</p>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => { setOutput(draftOutput); setDraftOutput(null); }}
+                  className="text-xs text-accent hover:text-white transition-colors font-medium"
+                >
+                  Restore
+                </button>
+                <button
+                  onClick={() => {
+                    try { localStorage.removeItem(`techscribe_draft_${slug}`); } catch { /* ignore */ }
+                    setDraftOutput(null);
+                  }}
+                  className="text-xs text-muted hover:text-white transition-colors"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Outline-editing phase: show summary + outline actions */}
           {isOutlineMode && articleStep === "outline-editing" ? (
@@ -650,7 +819,7 @@ function ToolPageContent() {
                   setArticleStep("input");
                   setOutput("");
                   setEditableOutline("");
-                  setSaved(false);
+              
                   setHistoryId(null);
                   setPublishedDraftUrl(null);
                   setPublishState(null);
@@ -690,8 +859,8 @@ function ToolPageContent() {
                           key={item.id}
                           className="flex items-start gap-2 bg-subtle border border-border rounded-lg px-3 py-2 text-xs"
                         >
-                          <span className="mt-0.5 shrink-0 font-mono text-accent">
-                            {item.type === "url" ? "🔗" : item.type === "file" ? "📄" : "📝"}
+                          <span className="mt-0.5 shrink-0 text-accent">
+                            {item.type === "url" ? <Link2 className="w-3.5 h-3.5" /> : item.type === "file" ? <FileText className="w-3.5 h-3.5" /> : <Pencil className="w-3.5 h-3.5" />}
                           </span>
                           <span className="flex-1 text-white/80 break-all line-clamp-2" title={item.label}>{item.label}</span>
                           <button
@@ -741,6 +910,32 @@ function ToolPageContent() {
                         includePhotos ? "translate-x-6" : "translate-x-1"
                       }`}
                     />
+                  </button>
+                </label>
+              )}
+
+              {/* Knowledge base toggle — always visible when entries exist */}
+              {knowledgeEntries.length > 0 && (
+                <label className="flex items-center justify-between gap-3 shell-panel-soft rounded-2xl px-4 py-3 cursor-pointer select-none">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <BookOpen className="w-4 h-4 text-accent shrink-0" />
+                    <div>
+                      <p className="text-xs font-mono uppercase tracking-wider text-slate-400 mb-0.5">Knowledge Base</p>
+                      <p className="text-xs text-slate-500 leading-relaxed">
+                        Include {knowledgeEntries.length} saved source{knowledgeEntries.length !== 1 ? "s" : ""} from your library.
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={includeKnowledge}
+                    onClick={() => setIncludeKnowledge((v) => !v)}
+                    className={`relative shrink-0 h-6 w-11 rounded-full border transition-colors focus:outline-none ${
+                      includeKnowledge ? "bg-accent border-accent" : "bg-subtle border-border"
+                    }`}
+                  >
+                    <span className={`block h-4 w-4 rounded-full bg-white shadow transition-transform ${includeKnowledge ? "translate-x-6" : "translate-x-1"}`} />
                   </button>
                 </label>
               )}
@@ -831,7 +1026,7 @@ function ToolPageContent() {
                     onClick={handleCopy}
                     className="flex items-center gap-1.5 btn-secondary"
                   >
-                    {copied ? "✓ Copied!" : "Copy"}
+                    Copy
                   </button>
                   {!loading && (
                     <button
@@ -857,7 +1052,7 @@ function ToolPageContent() {
                       onClick={handleSave}
                       className="flex items-center gap-1.5 btn-secondary"
                     >
-                      {saved ? "✓ Saved!" : "Save"}
+                      Save
                     </button>
                   )}
                   {/* Edit & Run Again / Reset Form — shown when article is done */}
@@ -942,7 +1137,7 @@ function ToolPageContent() {
             {!output && !loading && (
               <div className="flex flex-col items-center justify-center h-full text-center">
                 <EmptyState
-                  icon={tool.icon}
+                  icon={<Sparkles />}
                   eyebrow="Output Bay"
                   description={
                     <>

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import {
+  Search,
+  FileText,
+  Lightbulb,
+  TrendingUp,
+  Pencil,
+  Share2,
+  Mail,
+  Video,
+  ArrowRight,
+} from "lucide-react";
+import { TOOLS, CATEGORIES } from "@/lib/tools";
+
+const CATEGORY_ICONS: Record<string, React.ElementType> = {
+  "Content Creation": FileText,
+  "Ideas & Planning": Lightbulb,
+  "SEO & Keywords": TrendingUp,
+  "Editing & Rewriting": Pencil,
+  "Social Media": Share2,
+  "Email & Marketing": Mail,
+  "Video Content": Video,
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  "Content Creation": "text-teal-400 bg-teal-400/10",
+  "Ideas & Planning": "text-amber-400 bg-amber-400/10",
+  "SEO & Keywords": "text-sky-400 bg-sky-400/10",
+  "Editing & Rewriting": "text-violet-400 bg-violet-400/10",
+  "Social Media": "text-pink-400 bg-pink-400/10",
+  "Email & Marketing": "text-orange-400 bg-orange-400/10",
+  "Video Content": "text-red-400 bg-red-400/10",
+};
+
+export default function ToolsPage() {
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<string>("All");
+
+  const filtered = useMemo(() => {
+    return TOOLS.filter((tool) => {
+      const matchesCategory =
+        activeCategory === "All" || tool.category === activeCategory;
+      const query = search.toLowerCase();
+      const matchesSearch =
+        !query ||
+        tool.name.toLowerCase().includes(query) ||
+        tool.description.toLowerCase().includes(query) ||
+        tool.category.toLowerCase().includes(query);
+      return matchesCategory && matchesSearch;
+    });
+  }, [search, activeCategory]);
+
+  const groupedByCategory = useMemo(() => {
+    if (activeCategory !== "All") return null;
+    return CATEGORIES.reduce<Record<string, typeof TOOLS>>(
+      (acc, cat) => {
+        const tools = filtered.filter((t) => t.category === cat);
+        if (tools.length > 0) acc[cat] = tools;
+        return acc;
+      },
+      {}
+    );
+  }, [filtered, activeCategory]);
+
+  return (
+    <div className="min-h-screen">
+      {/* Header */}
+      <div className="border-b border-slate-200 bg-white px-8 py-8">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-[11px] font-mono tracking-[0.24em] uppercase text-accent mb-1">
+            Workspace
+          </p>
+          <h1
+            className="text-3xl font-semibold text-slate-900 mb-1"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            Tool Library
+          </h1>
+          <p className="text-slate-500 text-sm">
+            {TOOLS.length} AI writing tools across {CATEGORIES.length} categories
+          </p>
+
+          {/* Search */}
+          <div className="mt-6 relative max-w-lg">
+            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <input
+              type="text"
+              placeholder="Search tools…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-slate-200 bg-white text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-all"
+            />
+          </div>
+
+          {/* Category filters */}
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              onClick={() => setActiveCategory("All")}
+              className={`px-3.5 py-1.5 rounded-xl text-xs font-medium transition-all border ${
+                activeCategory === "All"
+                  ? "bg-accent text-white border-accent/30 shadow-sm"
+                  : "bg-white text-slate-600 border-slate-200 hover:border-slate-300 hover:text-slate-900"
+              }`}
+            >
+              All tools
+            </button>
+            {CATEGORIES.map((cat) => {
+              const Icon = CATEGORY_ICONS[cat];
+              return (
+                <button
+                  key={cat}
+                  onClick={() => setActiveCategory(cat)}
+                  className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-xl text-xs font-medium transition-all border ${
+                    activeCategory === cat
+                      ? "bg-accent text-white border-accent/30 shadow-sm"
+                      : "bg-white text-slate-600 border-slate-200 hover:border-slate-300 hover:text-slate-900"
+                  }`}
+                >
+                  {Icon && <Icon className="h-3 w-3" />}
+                  {cat}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Tool grid */}
+      <div className="px-8 py-8 max-w-5xl mx-auto">
+        {filtered.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-slate-400 text-sm">No tools match &ldquo;{search}&rdquo;</p>
+            <button
+              onClick={() => { setSearch(""); setActiveCategory("All"); }}
+              className="mt-3 text-accent text-sm hover:underline"
+            >
+              Clear filters
+            </button>
+          </div>
+        ) : activeCategory !== "All" ? (
+          <ToolGrid tools={filtered} />
+        ) : (
+          <div className="space-y-10">
+            {groupedByCategory &&
+              Object.entries(groupedByCategory).map(([cat, tools]) => {
+                const Icon = CATEGORY_ICONS[cat];
+                const colorClass = CATEGORY_COLORS[cat] ?? "text-slate-400 bg-slate-400/10";
+                return (
+                  <section key={cat}>
+                    <div className="flex items-center gap-2.5 mb-4">
+                      {Icon && (
+                        <div className={`h-7 w-7 rounded-lg flex items-center justify-center ${colorClass}`}>
+                          <Icon className="h-3.5 w-3.5" />
+                        </div>
+                      )}
+                      <h2 className="text-sm font-semibold text-slate-700">{cat}</h2>
+                      <span className="text-xs text-slate-400 ml-1">{tools.length}</span>
+                    </div>
+                    <ToolGrid tools={tools} />
+                  </section>
+                );
+              })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ToolGrid({ tools }: { tools: typeof TOOLS }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {tools.map((tool) => {
+        const colorClass = CATEGORY_COLORS[tool.category] ?? "text-slate-400 bg-slate-400/10";
+        const Icon = CATEGORY_ICONS[tool.category];
+        return (
+          <Link
+            key={tool.slug}
+            href={`/tool/${tool.slug}`}
+            className="group flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 hover:border-accent/40 hover:shadow-md transition-all"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className={`h-9 w-9 rounded-xl flex items-center justify-center shrink-0 ${colorClass}`}>
+                {Icon && <Icon className="h-4 w-4" />}
+              </div>
+              <ArrowRight className="h-4 w-4 text-slate-300 group-hover:text-accent group-hover:translate-x-0.5 transition-all mt-0.5 shrink-0" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-slate-800 mb-0.5">{tool.name}</p>
+              <p className="text-xs text-slate-500 leading-relaxed line-clamp-2">{tool.description}</p>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/DashboardPrimitives.tsx
+++ b/components/DashboardPrimitives.tsx
@@ -130,7 +130,7 @@ export function SurfaceNotice({ tone = "info", children, className }: SurfaceNot
 export function EmptyState({ icon, eyebrow, description, className }: EmptyStateProps) {
   return (
     <div className={clsx("shell-panel-soft rounded-[2rem] px-8 py-10 max-w-lg mx-auto text-center", className)}>
-      <div className="text-5xl mb-4 opacity-30">{icon}</div>
+      <div className="mb-4 opacity-30 flex justify-center text-5xl [&>svg]:w-12 [&>svg]:h-12">{icon}</div>
       <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-accent mb-3">{eyebrow}</p>
       <p className="text-slate-400 text-sm max-w-xs mx-auto">{description}</p>
     </div>

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { CheckCircle, AlertCircle, Info, X } from "lucide-react";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+type ToastTone = "success" | "error" | "info";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  tone: ToastTone;
+}
+
+interface ToastContextValue {
+  toast: (message: string, tone?: ToastTone) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ toast: () => {} });
+
+const TONE_CLASSES: Record<ToastTone, string> = {
+  success: "border-green-500/30 bg-green-500/10 text-green-300",
+  error:   "border-red-500/30   bg-red-500/10   text-red-300",
+  info:    "border-accent/30    bg-accent/10    text-accent",
+};
+
+const TONE_ICONS: Record<ToastTone, ReactNode> = {
+  success: <CheckCircle className="w-4 h-4 shrink-0" />,
+  error:   <AlertCircle className="w-4 h-4 shrink-0" />,
+  info:    <Info         className="w-4 h-4 shrink-0" />,
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const counter = useRef(0);
+
+  const toast = useCallback((message: string, tone: ToastTone = "success") => {
+    const id = ++counter.current;
+    setToasts((prev) => [...prev, { id, message, tone }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  const dismiss = (id: number) => setToasts((prev) => prev.filter((t) => t.id !== id));
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      {toasts.length > 0 && (
+        <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 pointer-events-none">
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              className={clsx(
+                "flex items-center gap-2.5 rounded-2xl border px-4 py-3 text-sm shadow-xl pointer-events-auto",
+                "animate-in slide-in-from-right-4 fade-in duration-200",
+                TONE_CLASSES[t.tone]
+              )}
+            >
+              {TONE_ICONS[t.tone]}
+              <span className="font-medium">{t.message}</span>
+              <button
+                onClick={() => dismiss(t.id)}
+                className="ml-1 opacity-60 hover:opacity-100 transition-opacity"
+                aria-label="Dismiss"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,20 +2,45 @@ import type { NextAuthOptions } from "next-auth";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import GoogleProvider from "next-auth/providers/google";
-import { upsertUser, getUserByGoogleId } from "@/lib/db";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { upsertUser, getUserByGoogleId, getDb } from "@/lib/db";
 import { sendNewUserNotification } from "@/lib/email";
+
+function upsertDevUser() {
+  getDb()
+    .prepare(
+      `INSERT INTO users (google_id, email, name, avatar, status, role)
+       VALUES ('dev-local', 'dev@local.dev', 'Dev User', NULL, 'approved', 'admin')
+       ON CONFLICT(google_id) DO UPDATE SET status = 'approved', role = 'admin'`
+    )
+    .run();
+}
 
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
     }),
+    ...(process.env.NODE_ENV === "development"
+      ? [
+          CredentialsProvider({
+            id: "dev-login",
+            name: "Dev Login",
+            credentials: {},
+            async authorize() {
+              upsertDevUser();
+              return { id: "dev-local", email: "dev@local.dev", name: "Dev User" };
+            },
+          }),
+        ]
+      : []),
   ],
   session: { strategy: "jwt" },
   pages: { signIn: "/login" },
   callbacks: {
     async signIn({ account, user }) {
+      if (account?.type === "credentials") return true;
       if (account?.provider !== "google") return false;
       const isNew = !getUserByGoogleId(account.providerAccountId);
       upsertUser({
@@ -33,9 +58,12 @@ export const authOptions: NextAuthOptions = {
       return true;
     },
 
-    async jwt({ token, account }) {
+    async jwt({ token, account, user }) {
       if (account?.provider === "google") {
         token.googleId = account.providerAccountId;
+      }
+      if (account?.type === "credentials" && user?.id) {
+        token.googleId = user.id;
       }
       // Re-fetch status on every JWT evaluation so approval takes effect on
       // the next session read without requiring a sign-out/sign-in cycle.

--- a/lib/handoff-registry.ts
+++ b/lib/handoff-registry.ts
@@ -172,6 +172,78 @@ export const HANDOFF_REGISTRY: HandoffRegistry = {
       fieldMap: { videoTitle: "topic" },
     },
   ],
+  "content-gap": [
+    {
+      label: "Build Outline",
+      targetSlug: "outline-generator",
+      fieldMap: { niche: "topic" },
+    },
+    {
+      label: "Write Article",
+      targetSlug: "article-writer",
+      fieldMap: { niche: "topic" },
+    },
+    {
+      label: "Cluster Keywords",
+      targetSlug: "keyword-cluster",
+      fieldMap: { niche: "niche" },
+    },
+  ],
+  "key-takeaways": [
+    {
+      label: "Create Tweet Thread",
+      targetSlug: "tweet-ideas",
+      fieldMap: { content: "topic" },
+    },
+    {
+      label: "Write LinkedIn Post",
+      targetSlug: "linkedin-post",
+      fieldMap: { content: "topic" },
+    },
+    {
+      label: "Write Newsletter",
+      targetSlug: "newsletter-writer",
+      fieldMap: { content: "summary" },
+    },
+  ],
+  "press-release": [
+    {
+      label: "Create Tweet Posts",
+      targetSlug: "tweet-ideas",
+      fieldMap: { headline: "topic" },
+    },
+    {
+      label: "Write LinkedIn Post",
+      targetSlug: "linkedin-post",
+      fieldMap: { headline: "topic" },
+    },
+  ],
+  "newsletter-writer": [
+    {
+      label: "Write Subject Line",
+      targetSlug: "email-subject-line",
+      fieldMap: { topic: "topic" },
+    },
+  ],
+  "podcast-show-notes": [
+    {
+      label: "Write LinkedIn Post",
+      targetSlug: "linkedin-post",
+      fieldMap: { title: "topic" },
+    },
+    {
+      label: "Create Tweet Posts",
+      targetSlug: "tweet-ideas",
+      fieldMap: { title: "topic" },
+    },
+  ],
+  "permalink-generator": [
+    {
+      label: "Generate OG Tags",
+      targetSlug: "og-meta-tags",
+      fieldMap: { title: "title", keyword: "description" },
+    },
+  ],
   "keyword-research-brief": [
     {
       label: "Write Article",

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -289,6 +289,21 @@ export const TOOLS: Tool[] = [
     userPromptTemplate: `Create a detailed SEO content brief from this keyword research data.\n\nContent Topic: {topic}\nTarget Audience: {audience}\nPrimary Search Intent: {intent}\n\nKeyword Research Data:\n{researchNotes}\n\nDeliver a complete content brief including:\n1. **Recommended Title** (SEO-optimized, under 60 chars)\n2. **Primary Keyword** and monthly search volume\n3. **Secondary Keywords** (5-10 supporting terms)\n4. **LSI Keywords** (semantic variations to include naturally)\n5. **Content Angle** — the unique positioning or hook\n6. **Recommended Word Count** based on keyword difficulty\n7. **Content Outline** (H2/H3 structure)\n8. **Key Points to Cover** (what top-ranking pages include)\n9. **CTA Recommendation**\n\nFormat clearly so a writer can act on it immediately.`,
   },
 
+  {
+    slug: "key-takeaways",
+    name: "Key Takeaways",
+    category: "Content Creation",
+    description: "Extract the core lessons and actionable insights from any article.",
+    icon: "🎯",
+    fields: [
+      { name: "content", label: "Article / Content", type: "textarea", placeholder: "Paste your blog post or article...", required: true, rows: 7 },
+      { name: "count", label: "Number of Takeaways", type: "select", options: ["3", "5", "7", "10"] },
+      { name: "format", label: "Output Format", type: "select", options: ["Bullet list", "Numbered list", "TL;DR paragraph + bullets", "Twitter-thread style"] },
+    ],
+    systemPrompt: `You are an expert content editor who extracts the most valuable, actionable insights from articles. Each takeaway should be something the reader can apply or remember — not just a summary of what was said.`,
+    userPromptTemplate: `Extract {count} key takeaways from this content, formatted as {format}:\n\n{content}\n\nMake each takeaway actionable and self-contained (readable without the article).`,
+  },
+
   // ── EDITING & REWRITING ──────────────────────────────────────
   {
     slug: "rewriter",
@@ -331,6 +346,33 @@ export const TOOLS: Tool[] = [
     userPromptTemplate: `Summarize the following content as a {format}:\n\n{content}`,
   },
   {
+    slug: "paraphrase",
+    name: "Paraphrase Tool",
+    category: "Editing & Rewriting",
+    description: "Rephrase text in different words while preserving the original meaning.",
+    icon: "🔁",
+    fields: [
+      { name: "content", label: "Text to Paraphrase", type: "textarea", placeholder: "Paste the text you want to rephrase...", required: true, rows: 6 },
+      { name: "style", label: "Style", type: "select", options: ["Natural rephrase", "More formal", "More casual", "Simpler language", "Creative (varied structure)"] },
+      { name: "count", label: "Variations", type: "select", options: ["1", "2", "3"] },
+    ],
+    systemPrompt: `You are an expert editor who paraphrases text accurately. Preserve all key information and meaning while using different words and sentence structures. Never change facts or omit key points.`,
+    userPromptTemplate: `Paraphrase this text {count} time(s) in a {style} style:\n\n{content}\n\nLabel each as "Version 1:", "Version 2:", etc. Preserve all meaning and facts.`,
+  },
+  {
+    slug: "grammar-fixer",
+    name: "Grammar & Style Fixer",
+    category: "Editing & Rewriting",
+    description: "Fix grammar, spelling, punctuation, and improve overall writing style.",
+    icon: "✅",
+    fields: [
+      { name: "content", label: "Text to Fix", type: "textarea", placeholder: "Paste your text here...", required: true, rows: 6 },
+      { name: "level", label: "Correction Level", type: "select", options: ["Grammar & spelling only", "Grammar + style improvements", "Full proofreading (grammar, style, clarity)"] },
+    ],
+    systemPrompt: `You are a professional proofreader and editor. Fix grammatical errors, spelling mistakes, and improve clarity as requested. Return the corrected text followed by a brief summary of changes.`,
+    userPromptTemplate: `Proofread and correct this text (level: {level}):\n\n{content}\n\nReturn:\n1. The fully corrected text\n2. A brief "Changes Made" section listing the key corrections`,
+  },
+  {
     slug: "explain-like-five",
     name: "Explain Like I'm 5",
     category: "Editing & Rewriting",
@@ -342,6 +384,38 @@ export const TOOLS: Tool[] = [
     ],
     systemPrompt: `You are a brilliant explainer who can make complex tech concepts understandable to anyone. Use simple words, real-world analogies, and short sentences. Avoid jargon entirely.`,
     userPromptTemplate: `Explain this in simple terms for a {audience}:\n\n{concept}\n\nUse an analogy from everyday life to make it click. Keep it friendly and encouraging.`,
+  },
+
+  // ── SEO & KEYWORDS (additions) ───────────────────────────────
+  // (existing: meta-title, meta-description, keyword-cluster, faq-writer, schema-markup, og-meta-tags, keyword-research-brief)
+
+  {
+    slug: "permalink-generator",
+    name: "URL / Permalink Generator",
+    category: "SEO & Keywords",
+    description: "Generate clean, SEO-friendly URL slugs for blog posts and pages.",
+    icon: "🔗",
+    fields: [
+      { name: "title", label: "Page Title or Topic", type: "text", placeholder: "e.g. The Complete Guide to React Hooks for Beginners", required: true },
+      { name: "keyword", label: "Primary Keyword (optional)", type: "text", placeholder: "e.g. react hooks tutorial" },
+      { name: "count", label: "Number of Options", type: "select", options: ["3", "5"] },
+    ],
+    systemPrompt: `You are an SEO specialist who creates clean, keyword-rich URL slugs. Follow best practices: lowercase, hyphens not underscores, remove stop words, under 75 characters, descriptive but concise.`,
+    userPromptTemplate: `Generate {count} URL slug options for:\nTitle: {title}\nPrimary keyword: {keyword}\n\nFor each:\n- Use hyphens between words\n- Remove stop words (the, a, an, for, in, etc.) unless they change meaning\n- Keep under 75 characters\n- Include the primary keyword when possible\n- Show character count\n\nFormat: /your-slug-here (XX chars)`,
+  },
+  {
+    slug: "content-gap",
+    name: "Content Gap Analyzer",
+    category: "SEO & Keywords",
+    description: "Compare your content against a competitor to find the topics and angles you're missing.",
+    icon: "🔭",
+    fields: [
+      { name: "yourContent", label: "Your Content / Topics Covered", type: "textarea", placeholder: "List your existing blog posts, topics, or paste an outline of what you've written about...", required: true, rows: 5 },
+      { name: "competitorContent", label: "Competitor Content / Topics", type: "textarea", placeholder: "Paste competitor post titles, a URL list, or describe what topics they cover...", required: true, rows: 5 },
+      { name: "niche", label: "Niche / Topic Area", type: "text", placeholder: "e.g. JavaScript development for beginners" },
+    ],
+    systemPrompt: `You are an SEO content strategist specialising in content gap analysis. Compare two content libraries and identify specific topics, angles, and keyword opportunities the first is missing. Be specific and actionable.`,
+    userPromptTemplate: `Perform a content gap analysis.\n\nNiche: {niche}\n\nMy Content:\n{yourContent}\n\nCompetitor Content:\n{competitorContent}\n\nDeliver:\n1. **Content Gaps** — Topics they cover that I don't (10+ specific ideas)\n2. **Angle Gaps** — Different approaches to shared topics I'm missing\n3. **Quick Wins** — 3 posts I should create first and why\n4. **Priority Ranking** — Which gaps to fill first based on likely traffic value`,
   },
 
   // ── SOCIAL MEDIA ─────────────────────────────────────────────
@@ -398,6 +472,34 @@ export const TOOLS: Tool[] = [
     userPromptTemplate: `Write a Pinterest pin description for a blog post about: {topic}\nKeywords to include: {keywords}\n\nMake it scannable, benefit-focused, and end with a soft CTA.`,
   },
 
+  {
+    slug: "instagram-caption",
+    name: "Instagram Caption",
+    category: "Social Media",
+    description: "Write engaging Instagram captions with hashtags for blog and content promotion.",
+    icon: "📸",
+    fields: [
+      { name: "topic", label: "Content / Post Topic", type: "text", placeholder: "e.g. My new article on the best AI tools for writers", required: true },
+      { name: "tone", label: "Tone", type: "select", options: ["Engaging & casual", "Inspirational", "Educational", "Behind-the-scenes", "Promotional"] },
+      { name: "count", label: "Number of Options", type: "select", options: ["2", "3"] },
+    ],
+    systemPrompt: `You are an Instagram content strategist for tech and content creators. Write captions with a strong hook first line, engaging body, and relevant hashtags. Keep it authentic and platform-native.`,
+    userPromptTemplate: `Write {count} Instagram caption options for: {topic}\nTone: {tone}\n\nFor each:\n- Strong hook first line\n- Body (2-4 sentences)\n- 8-12 relevant hashtags\n\nLabel each as "Option 1:", "Option 2:", etc.`,
+  },
+  {
+    slug: "tiktok-caption",
+    name: "TikTok Caption & Ideas",
+    category: "Social Media",
+    description: "Generate TikTok video ideas and captions to repurpose your blog content.",
+    icon: "🎵",
+    fields: [
+      { name: "topic", label: "Blog Post or Content Topic", type: "text", placeholder: "e.g. 5 VS Code extensions that changed my workflow", required: true },
+      { name: "style", label: "Video Style", type: "select", options: ["Quick tip / hack", "Storytime", "Tutorial teaser", "Hot take / opinion", "Trending sound concept"] },
+    ],
+    systemPrompt: `You are a TikTok content strategist for tech creators. Generate punchy video ideas and captions for TikTok's fast-paced format. Hook in the first second, deliver value throughout.`,
+    userPromptTemplate: `Generate 3 TikTok video ideas and captions based on: {topic}\nStyle: {style}\n\nFor each:\n- Video Concept (what to film, 1-2 sentences)\n- Caption (max 150 chars)\n- Hook line (first words of the video)\n- 5-7 hashtags`,
+  },
+
   // ── EMAIL & MARKETING ────────────────────────────────────────
   {
     slug: "email-subject-line",
@@ -439,6 +541,37 @@ export const TOOLS: Tool[] = [
     ],
     systemPrompt: `You are a direct response copywriter using the AIDA framework. Write persuasive copy that grabs attention, builds interest, creates desire, and compels action. Label each section clearly.`,
     userPromptTemplate: `Write AIDA copy for: {product}\nAudience: {audience}\n\nStructure:\n**Attention** — Grab them immediately\n**Interest** — Build curiosity about the problem/solution\n**Desire** — Paint the outcome they want\n**Action** — Clear, specific CTA`,
+  },
+
+  {
+    slug: "press-release",
+    name: "Press Release",
+    category: "Email & Marketing",
+    description: "Write a professional press release for product launches, announcements, or news.",
+    icon: "📰",
+    fields: [
+      { name: "headline", label: "News Headline", type: "text", placeholder: "e.g. TechScribe Studio Launches AI-Powered Content Calendar", required: true },
+      { name: "summary", label: "Key Details", type: "textarea", placeholder: "What happened? Key facts, context, any quotes...", required: true, rows: 5 },
+      { name: "company", label: "Company / Brand Name", type: "text", placeholder: "e.g. TechScribe Inc." },
+      { name: "contact", label: "Contact Information", type: "text", placeholder: "e.g. press@techscribe.com" },
+    ],
+    systemPrompt: `You are a PR professional who writes clear, newswire-ready press releases. Follow the standard inverted pyramid structure: dateline, strong lede, supporting details, quote, boilerplate, contact.`,
+    userPromptTemplate: `Write a professional press release:\n\nHeadline: {headline}\nKey Details: {summary}\nCompany: {company}\nContact: {contact}\n\nFormat:\n- FOR IMMEDIATE RELEASE header\n- City, Date — Lede (most important facts first)\n- Supporting body paragraphs\n- Quote paragraph\n- About / boilerplate\n- ### end marker\n- Contact info`,
+  },
+  {
+    slug: "newsletter-writer",
+    name: "Newsletter Writer",
+    category: "Email & Marketing",
+    description: "Write a complete email newsletter issue from your latest blog content.",
+    icon: "📩",
+    fields: [
+      { name: "topic", label: "Main Story / Blog Post Title", type: "text", placeholder: "e.g. 10 AI tools every developer needs in 2025", required: true },
+      { name: "summary", label: "Key Points to Highlight", type: "textarea", placeholder: "3-5 bullet points from your content...", rows: 4 },
+      { name: "tone", label: "Tone", type: "select", options: ["Friendly & personal", "Professional", "Curated & editorial", "Enthusiastic"] },
+      { name: "extras", label: "Extra Section", type: "select", options: ["None", "Quick tip of the week", "Tool recommendation", "Reader question", "What's coming next"] },
+    ],
+    systemPrompt: `You are an email newsletter writer for content creators. Write newsletters that feel like a letter from a friend — personal, valuable, and worth reading. Clear sections, scannable format.`,
+    userPromptTemplate: `Write a newsletter issue featuring: {topic}\nKey highlights: {summary}\nTone: {tone}\nExtra section: {extras}\n\nStructure:\n1. Suggested subject line\n2. Opening hook (personal, 2-3 sentences)\n3. Main story section (teaser of the post)\n4. Key takeaways (3 bullets)\n5. {extras} section (if not "None")\n6. Sign-off with soft CTA`,
   },
 
   // ── VIDEO CONTENT ────────────────────────────────────────────
@@ -486,6 +619,20 @@ export const TOOLS: Tool[] = [
     ],
     systemPrompt: `You are a YouTube content strategist. Write SEO-optimized video descriptions with a compelling intro (first 2 lines visible before "more"), full content overview, timestamp placeholders, and a CTA section. Format cleanly.`,
     userPromptTemplate: `Write a YouTube video description for:\nTitle: {title}\nContent: {summary}\n\nInclude:\n- Hook first 2 lines\n- Content overview\n- Timestamps (use [00:00] placeholders)\n- Subscribe/like CTA\n- Links section placeholder`,
+  },
+  {
+    slug: "podcast-show-notes",
+    name: "Podcast Show Notes",
+    category: "Video Content",
+    description: "Generate complete show notes from a podcast episode title and key points.",
+    icon: "🎙️",
+    fields: [
+      { name: "title", label: "Episode Title", type: "text", placeholder: "e.g. Ep. 42: The Future of AI in Content Marketing", required: true },
+      { name: "summary", label: "Episode Summary / Key Topics", type: "textarea", placeholder: "Key topics covered, guest name, main takeaways, timestamps if available...", required: true, rows: 5 },
+      { name: "guestName", label: "Guest Name (optional)", type: "text", placeholder: "e.g. Jane Smith, CEO of ContentCo" },
+    ],
+    systemPrompt: `You are a podcast producer who writes SEO-friendly show notes. Include a hook, episode summary, key takeaways, timestamps, and a resources section. Write for both listeners and search engines.`,
+    userPromptTemplate: `Write show notes for:\nEpisode: {title}\nGuest: {guestName}\nContent: {summary}\n\nInclude:\n1. Episode description (150-200 words, SEO-friendly)\n2. "In this episode..." section\n3. Key takeaways (5 bullets)\n4. Timestamps (use [00:00] placeholders)\n5. Resources & links ([placeholder])\n6. About the guest (if applicable)\n7. Subscribe/review CTA`,
   },
   {
     slug: "video-script-outline",

--- a/lib/use-knowledge-base.ts
+++ b/lib/use-knowledge-base.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface KnowledgeEntry {
+  id: string;
+  title: string;
+  type: "text" | "url";
+  content: string;
+  createdAt: string;
+}
+
+const STORAGE_KEY = "techscribe_knowledge_base";
+
+function load(): KnowledgeEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function save(entries: KnowledgeEntry[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // storage full or unavailable — silently ignore
+  }
+}
+
+export function useKnowledgeBase() {
+  const [entries, setEntries] = useState<KnowledgeEntry[]>([]);
+
+  useEffect(() => {
+    setEntries(load());
+  }, []);
+
+  const addEntry = useCallback((entry: Omit<KnowledgeEntry, "id" | "createdAt">) => {
+    const newEntry: KnowledgeEntry = {
+      ...entry,
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+    };
+    setEntries((prev) => {
+      const next = [newEntry, ...prev];
+      save(next);
+      return next;
+    });
+    return newEntry;
+  }, []);
+
+  const removeEntry = useCallback((id: string) => {
+    setEntries((prev) => {
+      const next = prev.filter((e) => e.id !== id);
+      save(next);
+      return next;
+    });
+  }, []);
+
+  return { entries, addEntry, removeEntry };
+}

--- a/lib/use-knowledge-base.ts
+++ b/lib/use-knowledge-base.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 export interface KnowledgeEntry {
   id: string;
@@ -33,11 +33,7 @@ function save(entries: KnowledgeEntry[]) {
 }
 
 export function useKnowledgeBase() {
-  const [entries, setEntries] = useState<KnowledgeEntry[]>([]);
-
-  useEffect(() => {
-    setEntries(load());
-  }, []);
+  const [entries, setEntries] = useState<KnowledgeEntry[]>(load);
 
   const addEntry = useCallback((entry: Omit<KnowledgeEntry, "id" | "createdAt">) => {
     const newEntry: KnowledgeEntry = {

--- a/lib/use-my-tone.ts
+++ b/lib/use-my-tone.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface ToneConfig {
+  preset: string;
+  formality: number;
+  sentenceLength: number;
+  voiceType: number;
+  customInstructions: string;
+}
+
+export const DEFAULT_TONE: ToneConfig = {
+  preset: "conversational",
+  formality: 2,
+  sentenceLength: 1,
+  voiceType: 0,
+  customInstructions: "",
+};
+
+const FORMALITY_LABELS = ["Very Formal", "Formal", "Neutral", "Casual", "Very Casual"];
+const SENTENCE_LABELS = ["Short & Punchy", "Balanced", "Long & Detailed"];
+const VOICE_LABELS = ["Active", "Passive", "Mixed"];
+const PRESET_DESCRIPTIONS: Record<string, string> = {
+  professional: "Clear, authoritative, and polished.",
+  conversational: "Warm, approachable, and easy to read.",
+  educational: "Structured and informative.",
+  persuasive: "Compelling and action-oriented.",
+  storytelling: "Narrative-driven and engaging.",
+};
+
+const STORAGE_KEY = "techscribe_my_tone";
+
+export function buildToneInstruction(config: ToneConfig): string {
+  const parts: string[] = [
+    `Tone/style: ${config.preset} — ${PRESET_DESCRIPTIONS[config.preset] ?? ""}`,
+    `Formality: ${FORMALITY_LABELS[config.formality] ?? "Neutral"}`,
+    `Sentence length: ${SENTENCE_LABELS[config.sentenceLength] ?? "Balanced"}`,
+    `Voice: ${VOICE_LABELS[config.voiceType] ?? "Active"}`,
+  ];
+  if (config.customInstructions.trim()) {
+    parts.push(`Additional instructions: ${config.customInstructions.trim()}`);
+  }
+  return `\n\nApply these tone and style preferences throughout:\n${parts.map((p) => `- ${p}`).join("\n")}`;
+}
+
+export function loadToneConfig(): ToneConfig {
+  if (typeof window === "undefined") return DEFAULT_TONE;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return { ...DEFAULT_TONE, ...JSON.parse(raw) };
+  } catch { /* ignore */ }
+  return DEFAULT_TONE;
+}
+
+export function useMyTone() {
+  const [config, setConfig] = useState<ToneConfig>(DEFAULT_TONE);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setConfig(loadToneConfig());
+    setLoaded(true);
+  }, []);
+
+  const save = useCallback((next: ToneConfig) => {
+    setConfig(next);
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+  }, []);
+
+  return { config, save, loaded };
+}

--- a/lib/use-my-tone.ts
+++ b/lib/use-my-tone.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 export interface ToneConfig {
   preset: string;
@@ -54,18 +54,12 @@ export function loadToneConfig(): ToneConfig {
 }
 
 export function useMyTone() {
-  const [config, setConfig] = useState<ToneConfig>(DEFAULT_TONE);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    setConfig(loadToneConfig());
-    setLoaded(true);
-  }, []);
+  const [config, setConfig] = useState<ToneConfig>(loadToneConfig);
 
   const save = useCallback((next: ToneConfig) => {
     setConfig(next);
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
   }, []);
 
-  return { config, save, loaded };
+  return { config, save, loaded: true };
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
         accent: "#0FA882",
         "accent-dim": "#0c8569",
         purple: "#7c3aed",
-        muted: "#8896A8",
+        muted: "#64748b",
         subtle: "#e2e8f0",
         status: {
           success: "#22c55e",


### PR DESCRIPTION
Phase 1-2: Sidebar refactor — removed per-tool nav links, added /tools library page with search + category filter; simplified dashboard (removed quick actions, templates, tool grid; kept stats, alerts, recent work).

Phase 3: SEO workspace tabs (Analysis/Workflow/Collaboration); Calendar editor tabs (Details/Brief/Workflow/Publishing); simplified Quick Plan form.

Phase 4: WorkflowStepper on tool pages for outline and direct modes.

Phase 5: Toast notification system (context-based, auto-dismiss); lucide icon replacements for all emoji; darkened muted text tokens.

Phase 6: 41 tools (up from 25); Blueprints page with 6 workflow cards; persistent Knowledge Base (localStorage); cannibalization check on history POST; MyTone persistence + wiring into every generate call; model selection in Settings; Cmd+Enter shortcut; draft autosave + recovery banner.