### PR TITLE
fix: persist SQLite data across container restarts using bind mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static    ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public          ./public
 
-# Pre-create persistent and tmpfs mount points so Docker can overlay them
-# at startup without needing to write to the read-only container filesystem.
+# Pre-create mount points so Docker can overlay them at startup without
+# needing to write to the read-only container filesystem.
 RUN mkdir -p /app/data /app/.next/cache \
  && chown nextjs:nodejs /app/data /app/.next/cache
-VOLUME /app/data
 
 USER nextjs
 EXPOSE 8989

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       DATA_DIR: /app/data
 
     volumes:
-      - techscribe-data:/app/data   # SQLite database — survives deployments
+      - ./data:/app/data   # SQLite database lives on the host — survives any docker command
 
     # Writable scratch space for Next.js fetch cache and OS temp files.
     tmpfs:
@@ -95,10 +95,4 @@ networks:
   traefik-public:
     external: true
 
-volumes:
-  techscribe-data:
-    name: techscribe-data
-    driver: local
-    # WARNING: never run "docker compose down -v" — the -v flag deletes this
-    # volume and all history/settings data with it. Use "docker compose down"
-    # (no -v) to stop and remove containers while keeping data intact.
+# No named volumes — data lives at ./data on the host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "8989:8989"
 
     volumes:
-      - techscribe-data:/app/data   # SQLite database — persists across container restarts
+      - ./data:/app/data   # SQLite database lives on the host — survives any docker command
 
     # Writable scratch space for Next.js fetch cache and OS temp files.
     # These are in-memory and discarded on container stop.
@@ -60,10 +60,5 @@ services:
       start_period: 60s
 
 
-volumes:
-  techscribe-data:
-    name: techscribe-data
-    driver: local
-    # WARNING: never run "docker compose down -v" — the -v flag deletes this
-    # volume and all history/settings data with it. Use "docker compose down"
-    # (no -v) to stop and remove containers while keeping data intact.
+# No named volumes — data lives at ./data on the host. Nothing Docker does
+# (down -v, volume prune, full reinstall) will touch those files.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -38,13 +38,16 @@ function closeDb() {
   }
 }
 
-// Close the database on process exit. Using the 'exit' event (not SIGTERM/SIGINT
-// directly) because Next.js registers its own SIGTERM handler via startServer
-// that calls process.exit(143) before our signal handler would run. The 'exit'
-// event fires synchronously inside process.exit() regardless of who initiated
-// it, so this is the only reliable hook in a Next.js standalone container.
+// Primary shutdown hook: fires synchronously inside process.exit() regardless
+// of who initiated it (Next.js calls process.exit(143) on SIGTERM).
 // better-sqlite3's db.close() is synchronous and triggers a WAL checkpoint.
 process.on("exit", closeDb);
+
+// Belt-and-suspenders: if something bypasses process.exit() entirely, still
+// checkpoint the WAL. These handlers call process.exit() which fires the
+// "exit" event above, so closeDb() only ever runs once.
+process.once("SIGTERM", () => process.exit(0));
+process.once("SIGINT",  () => process.exit(0));
 
 type CalendarEntryRow = Omit<CalendarEntry, "checklist_items"> & {
   checklist_items: CalendarChecklistItem[] | string[] | string | null;


### PR DESCRIPTION
Switched both compose files from a named Docker volume to a bind mount (./data:/app/data). Bind mounts are never touched by docker compose down -v, docker volume prune, or any other Docker lifecycle command — the database files simply live as regular files in ./data on the host.

Also added belt-and-suspenders SIGTERM/SIGINT handlers in db.ts so the WAL is checkpointed even if Next.js's own signal handler doesn't fire. Removed the VOLUME declaration from the Dockerfile since bind mounts in docker-compose take precedence anyway, and having both was confusing.