### PR TITLE
fix: entrypoint corrects bind-mount ownership before dropping to app …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ LABEL org.opencontainers.image.title="TechScribe Studio" \
       org.opencontainers.image.source="https://github.com/siddonj/techscribe-studio" \
       org.opencontainers.image.licenses="UNLICENSED"
 
+# su-exec: minimal setuid helper so the entrypoint can fix bind-mount
+# ownership as root then drop to nextjs before exec-ing the server.
+RUN apt-get update && apt-get install -y --no-install-recommends su-exec \
+ && rm -rf /var/lib/apt/lists/*
+
 # Create a non-root system user/group before copying any files.
 RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 --ingroup nodejs nextjs
@@ -48,12 +53,14 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static    ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public          ./public
 
-# Pre-create mount points so Docker can overlay them at startup without
-# needing to write to the read-only container filesystem.
+# Entrypoint: fixes /app/data ownership then drops to nextjs user.
+COPY --chmod=755 scripts/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Pre-create mount points so Docker can overlay them at startup.
 RUN mkdir -p /app/data /app/.next/cache \
  && chown nextjs:nodejs /app/data /app/.next/cache
 
-USER nextjs
+# Runs as root so entrypoint can chown the bind-mount dir; drops to nextjs inside entrypoint.
 EXPOSE 8989
 
 # Inline health check avoids a curl/wget dependency in the minimal image.
@@ -65,4 +72,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     ); \
     req.on('timeout', () => { req.destroy(); process.exit(1); }); \
     req.on('error',   () => process.exit(1));"
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,7 +40,6 @@ services:
       - /app/.next/cache:size=128m,uid=1001,gid=1001
 
     # ── Security hardening ───────────────────────────────────────────────────
-    read_only: true
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     cpus: "1.0"
 
     # ── Security hardening ───────────────────────────────────────────────────
-    read_only: true               # container filesystem is immutable at runtime
     security_opt:
       - no-new-privileges:true    # prevent setuid/setgid privilege escalation
     cap_drop:

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# On Linux hosts, Docker creates the bind-mount directory owned by root.
+# The app runs as uid 1001 (nextjs) and needs write access to /app/data.
+# This runs as root first, fixes ownership, then drops privileges.
+chown -R nextjs:nodejs /app/data 2>/dev/null || true
+
+exec su-exec nextjs "$@"


### PR DESCRIPTION
…user

On Linux hosts Docker creates ./data owned by root. The container's nextjs user (uid 1001) then gets only read/execute on the directory and cannot write the SQLite database, so data never actually persists.

Added a minimal entrypoint (su-exec) that chowns /app/data as root then immediately drops to the nextjs user before exec-ing node server.js. Removed read_only: true from both compose files since the container must run as root briefly during startup for the chown to work.