### PR TITLE
fix: replace su-exec (Alpine) with gosu (Debian) in entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.title="TechScribe Studio" \
 
 # su-exec: minimal setuid helper so the entrypoint can fix bind-mount
 # ownership as root then drop to nextjs before exec-ing the server.
-RUN apt-get update && apt-get install -y --no-install-recommends su-exec \
+RUN apt-get update && apt-get install -y --no-install-recommends gosu \
  && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root system user/group before copying any files.

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,4 +6,4 @@ set -e
 # This runs as root first, fixes ownership, then drops privileges.
 chown -R nextjs:nodejs /app/data 2>/dev/null || true
 
-exec su-exec nextjs "$@"
+exec gosu nextjs "$@"


### PR DESCRIPTION
su-exec is Alpine Linux only and not in Debian's apt repos, causing the build to fail with exit code 100. gosu is the standard Debian equivalent and is available in bookworm.