### PR TITLE
fix: pass VPS_SSH_PASSPHRASE to SSH deploy action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,6 +99,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_SSH_PASSPHRASE }}
           script: |
             cd ${{ secrets.VPS_DEPLOY_PATH }}
             docker compose --env-file .env -f docker-compose.prod.yml pull


### PR DESCRIPTION
## Summary

Every deploy job has been failing silently with:
```
ssh: this private key is passphrase protected
ssh: handshake failed: unable to authenticate
```

The `VPS_SSH_KEY` is a passphrase-protected key but no passphrase was ever supplied. **The VPS has never received any Docker image updates** — it has been running the original broken image throughout.

Adds `passphrase: ${{ secrets.VPS_SSH_PASSPHRASE }}` — ignored by the action if the secret is empty, so safe for both protected and unprotected keys.

## To unblock deploys — do one of these before merging

**Option A (recommended):** Replace `VPS_SSH_KEY` with a new unprotected key:
```bash
# On your VPS:
ssh-keygen -t ed25519 -C "github-ci-deploy" -N "" -f ~/.ssh/ci_deploy
cat ~/.ssh/ci_deploy.pub >> ~/.ssh/authorized_keys
cat ~/.ssh/ci_deploy   # paste this as the new VPS_SSH_KEY secret
```
Leave `VPS_SSH_PASSPHRASE` unset.

**Option B:** Keep the existing key — add a `VPS_SSH_PASSPHRASE` secret with its passphrase.

## Test plan
- [ ] Complete Option A or B above
- [ ] Merge this PR
- [ ] Watch "Deploy to VPS" job succeed in Actions
- [ ] SSH to VPS: confirm container is running new image (`docker ps`)
- [ ] Create article → `docker compose down && docker compose up -d` → confirm history persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)