### PR TITLE
fix: use traefik_default network to match actual Traefik setup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
 
     networks:
-      - traefik-public
+      - traefik_default
 
     # Load all secrets/config from .env; override infrastructure-only vars inline.
     env_file: .env
@@ -73,7 +73,7 @@ services:
     # ── Traefik labels ───────────────────────────────────────────────────────
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=traefik-public"
+      - "traefik.docker.network=traefik_default"
       # HTTP → HTTPS redirect
       - "traefik.http.routers.techscribe-http.rule=Host(`${DOMAIN:-techscribe.example.com}`)"
       - "traefik.http.routers.techscribe-http.entrypoints=web"
@@ -91,7 +91,7 @@ services:
       - "traefik.http.routers.techscribe.middlewares=techscribe-buffering"
 
 networks:
-  traefik-public:
+  traefik_default:
     external: true
 
 # No named volumes — data lives at ./data on the host.


### PR DESCRIPTION
## Summary

- Changes `traefik-public` → `traefik_default` in the external network declaration, service network attachment, and `traefik.docker.network` label
- The container was connecting to a network Traefik wasn't on, so Traefik returned 404 for all requests

## Also required on the VPS

Ensure `.env` contains:
```
DOMAIN=app.techscribe.org
```

## Test plan
- [ ] Merge → CI deploys → `https://app.techscribe.org` loads
- [ ] Create article → `docker compose down && docker compose up -d` → history persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)