### PR TITLE
fix: remove Traefik labels, expose port for Nginx Proxy Manager

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,8 +20,8 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY:-siddonj/techscribe-studio}:${IMAGE_TAG:-latest}
     restart: unless-stopped
 
-    networks:
-      - traefik_default
+    ports:
+      - "8989:8989"
 
     # Load all secrets/config from .env; override infrastructure-only vars inline.
     env_file: .env
@@ -69,29 +69,5 @@ services:
         reservations:
           cpus: "0.25"
           memory: 256M
-
-    # ── Traefik labels ───────────────────────────────────────────────────────
-    labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=traefik_default"
-      # HTTP → HTTPS redirect
-      - "traefik.http.routers.techscribe-http.rule=Host(`${DOMAIN:-techscribe.example.com}`)"
-      - "traefik.http.routers.techscribe-http.entrypoints=web"
-      - "traefik.http.routers.techscribe-http.middlewares=redirect-to-https"
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
-      # HTTPS router
-      - "traefik.http.routers.techscribe.rule=Host(`${DOMAIN:-techscribe.example.com}`)"
-      - "traefik.http.routers.techscribe.entrypoints=websecure"
-      - "traefik.http.routers.techscribe.tls=true"
-      - "traefik.http.routers.techscribe.tls.certresolver=letsencrypt"
-      # Service backend port
-      - "traefik.http.services.techscribe.loadbalancer.server.port=8989"
-      # Disable response buffering so streaming AI generation works correctly
-      - "traefik.http.middlewares.techscribe-buffering.buffering.maxResponseBodyBytes=0"
-      - "traefik.http.routers.techscribe.middlewares=techscribe-buffering"
-
-networks:
-  traefik_default:
-    external: true
 
 # No named volumes — data lives at ./data on the host.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,8 +20,8 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY:-siddonj/techscribe-studio}:${IMAGE_TAG:-latest}
     restart: unless-stopped
 
-    ports:
-      - "8989:8989"
+    networks:
+      - nginx_proxy_manager_default
 
     # Load all secrets/config from .env; override infrastructure-only vars inline.
     env_file: .env
@@ -69,5 +69,9 @@ services:
         reservations:
           cpus: "0.25"
           memory: 256M
+
+networks:
+  nginx_proxy_manager_default:
+    external: true
 
 # No named volumes — data lives at ./data on the host.


### PR DESCRIPTION
## Summary

Replaced Traefik with Nginx Proxy Manager for simpler reverse proxy setup.

- Remove all Traefik labels (traefik.enable, traefik.http.routers, etc.)
- Remove traefik_default network declaration and attachment
- Add `ports: - "8989:8989"` to expose the app port directly
- NPM will reverse proxy from outside the container

## Test plan
- [ ] Merge → CI deploys
- [ ] NPM routing works → `https://app.techscribe.org` loads
- [ ] Create article → persist across `docker compose down && docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)