### PR TITLE
ci: disable SSH deploy job, use webhook instead

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,7 +89,7 @@ jobs:
     name: Deploy to VPS
     runs-on: ubuntu-latest
     needs: docker-publish
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: false
     environment: production
 
     steps:


### PR DESCRIPTION
The SSH deploy job has been timing out due to network issues. The webhook-based deployment on the VPS is working correctly, so this job is no longer needed.