### PR TITLE
fix: dashboard SQL table name, Unsplash API integration, and marked Markdown converter

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -36,6 +36,11 @@ SMTP_PASS=your-smtp-password
 SMTP_FROM=TechScribe Studio <you@yourdomain.com>
 ADMIN_EMAIL=you@yourdomain.com
 
+# ── Images (optional) ──────────────────────────────────────────────────────────
+# Unsplash Access Key for automatic photo embedding in generated articles.
+# Get one at https://unsplash.com/developers — leave unset to use placeholders.
+UNSPLASH_ACCESS_KEY=
+
 # ── Production Docker (docker-compose.prod.yml) ───────────────────────────────
 # Your public domain — must match the Traefik router rule
 DOMAIN=techscribe.example.com

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -26,6 +26,49 @@ function buildResearchSection(research: ResearchItem[]): string {
   return `\n\nResearch Sources:\n${items}`;
 }
 
+/**
+ * Fetches real Unsplash image URLs when an access key is configured.
+ * Falls back to null so the caller can use placeholder instructions.
+ */
+async function fetchUnsplashPhotos(keyword: string, count: number): Promise<string[] | null> {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) return null;
+
+  try {
+    const res = await fetch(
+      `https://api.unsplash.com/search/photos?query=${encodeURIComponent(keyword)}&per_page=${count}&orientation=landscape`,
+      { headers: { Authorization: `Client-ID ${accessKey}` }, cache: "no-store" }
+    );
+    if (!res.ok) {
+      console.error(`[unsplash] API error ${res.status}: ${await res.text()}`);
+      return null;
+    }
+    const data = (await res.json()) as { results: Array<{ urls: { raw: string } }> };
+    return data.results.map((r) => `${r.urls.raw}&w=1200&h=628&fit=crop&q=80`);
+  } catch (err) {
+    console.error("[unsplash] fetch failed:", err);
+    return null;
+  }
+}
+
+function buildPhotoInstructions(photoUrls: string[] | null): string {
+  if (photoUrls && photoUrls.length > 0) {
+    return (
+      "\n\nPhoto instructions: Embed these royalty-free photos throughout the article at natural break points between sections. " +
+      "Use each photo exactly once with this Markdown format on its own line:\n" +
+      photoUrls.map((url) => `![Relevant descriptive caption — Photo via Unsplash](${url})`).join("\n") +
+      "\n\nDo not cluster photos together; spread them evenly across the article."
+    );
+  }
+
+  return (
+    "\n\nPhoto instructions: Embed 3–5 relevant image placeholders throughout the article at natural break points between sections. " +
+    "For each photo use this exact Markdown format on its own line:\n" +
+    "![A descriptive caption explaining what the photo shows — Photo needed](https://placehold.co/1200x628?text=Replace+with+real+image)\n" +
+    "Set the UNSPLASH_ACCESS_KEY environment variable to automatically inject real Unsplash photo URLs."
+  );
+}
+
 export async function POST(req: NextRequest) {
   const auth = await requireApprovedSession();
   if ("error" in auth) return auth.error;
@@ -110,18 +153,10 @@ export async function POST(req: NextRequest) {
     }
 
     // Append photo-embedding instructions when the option is enabled.
-    // TODO: source.unsplash.com/featured is deprecated by Unsplash. To migrate to a
-    // supported API, add an UNSPLASH_ACCESS_KEY (or PEXELS_API_KEY / PIXABAY_API_KEY)
-    // environment variable, fetch a real image URL server-side before generation, and
-    // inject resolved URLs into the prompt instead of using the source redirect pattern.
     if (includePhotos) {
-      userPrompt +=
-        "\n\nPhoto instructions: Embed 3–5 relevant royalty-free photos throughout the article at natural break points between sections. " +
-        "For each photo use this exact Markdown format on its own line (replace the bracketed parts with real content):\n" +
-        "![A descriptive caption explaining what the photo shows — Photo via Unsplash](https://source.unsplash.com/featured/1200x628/?actual-keyword)\n" +
-        "For the URL, replace 'actual-keyword' with a specific, descriptive search term (use hyphens between words, no spaces) that will return highly relevant images for the surrounding content. " +
-        "Example: for a section about JavaScript performance, use 'javascript-code' or 'web-performance'. " +
-        "Do not cluster photos together; spread them evenly across the article.";
+      const keyword = fields.keywords || fields.topic || fields.videoTitle || "technology";
+      const photoUrls = await fetchUnsplashPhotos(keyword, 5);
+      userPrompt += buildPhotoInstructions(photoUrls);
     }
 
     const ALLOWED_MODELS = new Set(["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-7"]);
@@ -169,4 +204,3 @@ export async function POST(req: NextRequest) {
     );
   }
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ async function getDashboardData(isAdmin: boolean) {
     ).get() as { count: number }).count;
 
     const todayItems = (db.prepare(
-      "SELECT COUNT(*) as count FROM calendar WHERE scheduled_for = date('now') AND status != 'published'"
+      "SELECT COUNT(*) as count FROM content_calendar WHERE scheduled_for = date('now') AND status != 'published'"
     ).get() as { count: number }).count;
 
     const failedPublishes = (db.prepare(
@@ -44,7 +44,7 @@ async function getDashboardData(isAdmin: boolean) {
     ).all() as { id: number; title: string; tool_name: string; tool_icon: string; created_at: string }[];
 
     const upcomingItems = db.prepare(
-      "SELECT id, title, scheduled_for, status FROM calendar WHERE scheduled_for >= date('now') AND status != 'published' ORDER BY scheduled_for ASC LIMIT 5"
+      "SELECT id, title, scheduled_for, status FROM content_calendar WHERE scheduled_for >= date('now') AND status != 'published' ORDER BY scheduled_for ASC LIMIT 5"
     ).all() as { id: number; title: string; scheduled_for: string; status: string }[];
 
     return { recentSaves, todayItems, failedPublishes, pendingUsers, recentHistory, upcomingItems };

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -1,3 +1,4 @@
+import { marked } from "marked";
 import { getWordPressSettings } from "@/lib/db";
 
 export interface WordPressConfig {
@@ -6,36 +7,17 @@ export interface WordPressConfig {
   appPassword: string;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
+/**
+ * Convert Markdown to WordPress-compatible HTML.
+ *
+ * Uses `marked` for robust, spec-compliant parsing instead of the previous
+ * regex-based converter which broke on nested formatting, code blocks with
+ * special characters, and complex lists.
+ */
 export function markdownToWordPressHtml(markdown: string): string {
-  return markdown
-    .replace(/```[\w]*\n([\s\S]*?)```/g, (_match, code) => {
-      return `<pre><code>${escapeHtml(String(code).trim())}</code></pre>`;
-    })
-    .replace(/^### (.+)$/gm, "<h3>$1</h3>")
-    .replace(/^## (.+)$/gm, "<h2>$1</h2>")
-    .replace(/^# (.+)$/gm, "<h1>$1</h1>")
-    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
-    .replace(/`([^`]+)`/g, (_match, code) => `<code>${escapeHtml(code)}</code>`)
-    .replace(/^---$/gm, "<hr />")
-    .replace(/^\d+\.\s+(.+)$/gm, "<li>$1</li>")
-    .replace(/^[-*]\s+(.+)$/gm, "<li>$1</li>")
-    .replace(/(<li>[\s\S]*?<\/li>)/g, "<ul>$1</ul>")
-    .replace(/<\/ul>\s*<ul>/g, "")
-    .replace(/\n\n/g, "</p><p>")
-    .replace(/^(?!<[hupol]|<\/[hupol]|<li|<hr)(.+)$/gm, (match) =>
-      match.startsWith("<") ? match : `<p>${match}</p>`
-    )
-    .replace(/<p><\/p>/g, "");
+  // marked returns a Promise in async mode; synchronous call returns a string.
+  const html = marked.parse(markdown, { async: false }) as string;
+  return html.trim();
 }
 
 export function resolveWordPressConfig(overrides?: Partial<WordPressConfig>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "better-sqlite3": "^12.9.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.383.0",
+        "marked": "^14.0.0",
         "next": "^16.2.3",
         "next-auth": "^4.24.14",
         "nodemailer": "^7.0.13",
@@ -5950,6 +5951,18 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "better-sqlite3": "^12.9.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.383.0",
+    "marked": "^14.0.0",
     "next": "^16.2.3",
     "next-auth": "^4.24.14",
     "nodemailer": "^7.0.13",


### PR DESCRIPTION
## Summary

This PR addresses three critical issues identified in the codebase review:

### 1. Dashboard calendar queries referencing wrong table name
- `app/page.tsx`: Changed `FROM calendar` -> `FROM content_calendar` in both the "scheduled today" count and "upcoming items" queries. These were silently returning zeros because the table name didn't match the actual SQLite schema.

### 2. Deprecated Unsplash `source.unsplash.com` redirect replaced with real API
- `app/api/generate/route.ts`: Added `fetchUnsplashPhotos()` helper that calls the Unsplash Search Photos API when `UNSPLASH_ACCESS_KEY` is configured. Real direct image URLs are injected into the generation prompt. Falls back to `placehold.co` placeholders with a helpful note when the key is absent or the call fails.
- `.env.local.example`: Added `UNSPLASH_ACCESS_KEY` with setup instructions.

### 3. Regex-based Markdown-to-HTML converter replaced with `marked`
- `lib/wordpress.ts`: Removed the fragile hand-rolled regex parser and replaced it with `marked.parse()` for robust, spec-compliant Markdown-to-HTML conversion. This eliminates edge-case breakage with nested formatting, code blocks with special characters, and complex lists.
- `package.json`: Added `marked ^14.0.0` dependency.

## Merge notes
This branch also incorporates recent upstream changes from `origin/main`, including WordPress URL security hardening (hostname validation, IP blocking, DNS resolution checks).
